### PR TITLE
Improve package and start fixing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+# Config file for automatic testing at travis-ci.org
+
+language: python
+
+python:
+  - "3.4"
+  - "3.3"
+  - "2.7"
+  - "2.6"
+  - "pypy"
+
+# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+install: pip install -r requirements.txt
+
+# command to run tests, e.g. python setup.py test
+script: python setup.py test

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -98,7 +98,7 @@ Before you submit a pull request, check that it meets these guidelines:
 1. The pull request should include tests.
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
-   feature to the list in README.txt.
+   feature to the list in README.md.
 3. The pull request should work for Python 2.6, 2.7, 3.3, and 3.4, and for PyPy. Check
    https://travis-ci.org/ably/ably-python/pull_requests
    and make sure that the tests pass for all supported Python versions.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,111 @@
+============
+Contributing
+============
+
+Contributions are welcome, and they are greatly appreciated! Every
+little bit helps, and credit will always be given.
+
+You can contribute in many ways:
+
+Types of Contributions
+----------------------
+
+Report Bugs
+~~~~~~~~~~~
+
+Report bugs at https://github.com/ably/ably-python/issues.
+
+If you are reporting a bug, please include:
+
+* Your operating system name and version.
+* Any details about your local setup that might be helpful in troubleshooting.
+* Detailed steps to reproduce the bug.
+
+Fix Bugs
+~~~~~~~~
+
+Look through the GitHub issues for bugs. Anything tagged with "bug"
+is open to whoever wants to implement it.
+
+Implement Features
+~~~~~~~~~~~~~~~~~~
+
+Look through the GitHub issues for features. Anything tagged with "feature"
+is open to whoever wants to implement it.
+
+Write Documentation
+~~~~~~~~~~~~~~~~~~~
+
+ably-python could always use more documentation, whether as part of the
+official ably-python docs, in docstrings, or even on the web in blog posts,
+articles, and such.
+
+Submit Feedback
+~~~~~~~~~~~~~~~
+
+The best way to send feedback is to file an issue at https://github.com/ably/ably-python/issues.
+
+If you are proposing a feature:
+
+* Explain in detail how it would work.
+* Keep the scope as narrow as possible, to make it easier to implement.
+* Remember that this is a volunteer-driven project, and that contributions
+  are welcome :)
+
+Get Started!
+------------
+
+Ready to contribute? Here's how to set up `ably-python` for local development.
+
+1. Fork the `ably-python` repo on GitHub.
+2. Clone your fork locally::
+
+    $ git clone git@github.com:your_name_here/ably-python.git
+
+3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
+
+    $ mkvirtualenv ably-python
+    $ cd ably-python/
+    $ python setup.py develop
+
+4. Create a branch for local development::
+
+    $ git checkout -b name-of-your-bugfix-or-feature
+
+   Now you can make your changes locally.
+
+5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
+
+    $ flake8 ably test
+    $ python setup.py test
+    $ tox
+
+   To get flake8 and tox, just pip install them into your virtualenv.
+
+6. Commit your changes and push your branch to GitHub::
+
+    $ git add .
+    $ git commit -m "Your detailed description of your changes."
+    $ git push origin name-of-your-bugfix-or-feature
+
+7. Submit a pull request through the GitHub website.
+
+Pull Request Guidelines
+-----------------------
+
+Before you submit a pull request, check that it meets these guidelines:
+
+1. The pull request should include tests.
+2. If the pull request adds functionality, the docs should be updated. Put
+   your new functionality into a function with a docstring, and add the
+   feature to the list in README.rst.
+3. The pull request should work for Python 2.6, 2.7, 3.3, and 3.4, and for PyPy. Check
+   https://travis-ci.org/ably/ably-python/pull_requests
+   and make sure that the tests pass for all supported Python versions.
+
+Tips
+----
+
+To run a subset of tests::
+
+    $ python -m unittest test.ably.restappstats_test

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -98,7 +98,7 @@ Before you submit a pull request, check that it meets these guidelines:
 1. The pull request should include tests.
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
-   feature to the list in README.rst.
+   feature to the list in README.txt.
 3. The pull request should work for Python 2.6, 2.7, 3.3, and 3.4, and for PyPy. Check
    https://travis-ci.org/ably/ably-python/pull_requests
    and make sure that the tests pass for all supported Python versions.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,0 +1,9 @@
+.. :changelog:
+
+History
+-------
+
+0.1.0 (2015-05-12)
+---------------------
+
+* First release on PyPI.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include AUTHORS.rst
 include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
-include README.rst
+include README.txt
 
 recursive-include test *
 recursive-exclude * __pycache__

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include AUTHORS.rst
 include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
-include README.txt
+include README.md
 
 recursive-include test *
 recursive-exclude * __pycache__

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,11 @@
+include AUTHORS.rst
+include CONTRIBUTING.rst
+include HISTORY.rst
+include LICENSE
+include README.rst
+
+recursive-include test *
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]
+
+recursive-include docs *.rst conf.py Makefile make.bat

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,70 @@
+.PHONY: clean-pyc clean-build docs clean test
+
+help:
+	@echo "clean - remove all build, test, coverage and Python artifacts"
+	@echo "clean-build - remove build artifacts"
+	@echo "clean-pyc - remove Python file artifacts"
+	@echo "clean-test - remove test and coverage artifacts"
+	@echo "lint - check style with flake8"
+	@echo "test - run tests quickly with the default Python"
+	@echo "test-all - run tests on every Python version with tox"
+	@echo "coverage - check code coverage quickly with the default Python"
+	@echo "docs - generate Sphinx HTML documentation, including API docs"
+	@echo "release - package and upload a release"
+	@echo "dist - package"
+	@echo "install - install the package to the active Python's site-packages"
+
+clean: clean-build clean-pyc clean-test
+
+clean-build:
+	rm -fr build/
+	rm -fr dist/
+	rm -fr .eggs/
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
+
+clean-pyc:
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+clean-test:
+	rm -fr .tox/
+	rm -f .coverage
+	rm -fr htmlcov/
+
+lint:
+	flake8 ably-python test
+
+test:
+	python setup.py test
+
+test-all:
+	tox
+
+coverage:
+	coverage run --source ably-python setup.py test
+	coverage report -m
+	coverage html
+	open htmlcov/index.html
+
+docs:
+	rm -f docs/ably-python.rst
+	rm -f docs/modules.rst
+	sphinx-apidoc -o docs/ ably-python
+	$(MAKE) -C docs clean
+	$(MAKE) -C docs html
+	open docs/_build/html/index.html
+
+release: clean
+	python setup.py sdist upload
+	python setup.py bdist_wheel upload
+
+dist: clean
+	python setup.py sdist
+	python setup.py bdist_wheel
+	ls -l dist
+
+install: clean
+	python setup.py install

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 ably-python
 -----------
 
-Ably.io python client library - REST interface
+.. image:: https://img.shields.io/travis/ably/ably-python.svg
+        :target: https://travis-ci.org/ably/ably-python
+
+.. image:: https://img.shields.io/pypi/v/ably-python.svg
+        :target: https://pypi.python.org/pypi/ably-python
+
+
+Python REST client for Ably real-time messaging service
 
 ## Dependencies
 

--- a/ably/http/http.py
+++ b/ably/http/http.py
@@ -32,7 +32,7 @@ def fallback(func):
         for host in fallback_hosts:
             try:
                 kwargs["host"] = host
-                return func(rest, *args, **kwargs)
+                return func(http, *args, **kwargs)
             except requests.exceptions.ConnectionError as e:
                 # TODO: as above
                 last_exception = e

--- a/ably/rest/rest.py
+++ b/ably/rest/rest.py
@@ -68,7 +68,6 @@ class AblyRest(object):
         except:
             return '%s' % t
 
-    @catch_all
     def stats(self, direction=None, start=None, end=None, params=None,
               limit=None, paginated=None, by=None, timeout=None):
         """Returns the stats for this application"""

--- a/ably/types/stats.py
+++ b/ably/types/stats.py
@@ -138,8 +138,8 @@ class Stats(object):
             "persisted": MessageTypes.from_dict(stats_dict.get("persisted")),
             "connections": ConnectionTypes.from_dict(stats_dict.get("connections")),
             "channels": ResourceCount.from_dict(stats_dict["channels"]),
-            "api_requests": RequestCount.from_dict(stats_dict["apiRequests"]),
-            "token_requests": RequestCount.from_dict(stats_dict["tokenRequests"]),
+            "api_requests": RequestCount.from_dict(stats_dict.get("apiRequests", 0)),
+            "token_requests": RequestCount.from_dict(stats_dict.get("tokenRequests", 0)),
         }
 
         return Stats(**kwargs)

--- a/ably/util/exceptions.py
+++ b/ably/util/exceptions.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 class AblyException(BaseException, UnicodeMixin):
     def __init__(self, reason, status_code, code):
-        super(AblyException, self).__init__()
+        super(AblyException, self).__init__(reason)
         self.reason = reason
         self.code = code
         self.status_code = status_code

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pycrypto==2.6.1
 requests==2.6.0
 six==1.9.0
 #wsgiref==0.1.2,<2
+wheel==0.23.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
     from distutils.core import setup
 
 
-with open('README.rst') as readme_file:
+with open('README.txt') as readme_file:
     readme = readme_file.read()
 
 with open('HISTORY.rst') as history_file:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
     from distutils.core import setup
 
 
-with open('README.txt') as readme_file:
+with open('README.md') as readme_file:
     readme = readme_file.read()
 
 with open('HISTORY.rst') as history_file:

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,61 @@
-from setuptools import setup
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+
+with open('README.rst') as readme_file:
+    readme = readme_file.read()
+
+with open('HISTORY.rst') as history_file:
+    history = history_file.read().replace('.. :changelog:', '')
+
+requirements = [
+    'msgpack-python==0.4.6',
+    'pycrypto==2.6.1',
+    'requests==2.6.0',
+    'six==1.9.0',
+]
+
+test_requirements = [
+    'nose==1.3.6',
+    'responses==0.3.0',
+    'mock==1.0.1',
+]
 
 setup(
     name='ably-python',
-    version='0.1dev',
-    classifiers=[
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
+    version='0.1.0',
+    description="Python REST client for Ably real-time messaging service",
+    long_description=readme + '\n\n' + history,
+    # author="",
+    # author_email='',
+    # license="",
+    url='https://github.com/ably/ably-python',
+    packages=[
+        'ably',
     ],
-    packages=['ably',],
-    install_requires=['requests>=1.0.0',],
-    long_description='',
+    package_dir={'ably': 'ably'},
+    include_package_data=True,
+    install_requires=requirements,
+    zip_safe=False,
+    keywords='ably',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        # 'License :: OSI Approved :: BSD License',
+        'Natural Language :: English',
+        "Programming Language :: Python :: 2",
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+    ],
     test_suite='nose.collector',
-    tests_require=['nose>=1.0.0',]
+    tests_require=test_requirements
 )
-

--- a/test/ably/__init__.py
+++ b/test/ably/__init__.py
@@ -1,8 +1,0 @@
-from test.ably.restsetup import RestSetup
-
-def setup_package():
-    RestSetup.get_test_vars()
-
-def teardown_package():
-    RestSetup.clear_test_vars()
-

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -2,67 +2,80 @@ from __future__ import absolute_import
 
 import logging
 import unittest
-import os 
+import responses
+import mock
+
+from os.path import join, abspath, dirname, normpath
 
 from ably import AblyRest
 from ably import Auth
 from ably import Options
-
-
-from test.ably.restsetup import RestSetup
-
-test_vars = RestSetup.get_test_vars()
-
+from ably.util.exceptions import AblyException
 
 log = logging.getLogger(__name__)
 
+
 class TestAuth(unittest.TestCase):
+
+    def _add_stats_responses(self):
+        with open(normpath(join(abspath(dirname(__file__)), '..', 'api_responses', 'stats.json'))) as f:
+            body = f.read()
+        responses.add(
+            responses.GET, 'https://rest.ably.io:443/stats',
+            body=body, status=200,
+            content_type='application/json',
+            adding_headers={
+                'access-control-expose-headers': 'Link',
+                'vary': 'Origin', 'connection': 'keep-alive',
+                'link': '<./stats?start=0&end=1431454230723&limit=100&unit=minute&'
+                        'direction=backwards&format=json&first_end=1431454230723>; rel="first", '
+                        '<./stats?start=0&end=1431454230723&limit=100&unit=minute&'
+                        'direction=backwards&format=json&first_end=1431454230723>; rel="current"',
+                'access-control-allow-credentials': 'true',
+                'date': 'Tue, 12 May 2015 18:10:30 GMT',
+                'access-control-allow-origin': '*'
+            })
+        responses.add(
+            responses.POST, 'https://rest.ably.io:443/keys/mykey.myvalue/requestToken',
+            body='{"error": {"statusCode": 401, "code": 40101, "message": "No keyName specified" }}',
+            status=401, content_type='application/json',
+            adding_headers={
+                'access-control-expose-headers': 'Link',
+                'vary': 'Origin', 'connection': 'keep-alive',
+                'access-control-allow-credentials': 'true',
+                'date': 'Tue, 12 May 2015 18:10:30 GMT',
+                'access-control-allow-origin': '*'
+            })
+
     def test_auth_init_key_only(self):
-        
-        ably = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"]))
-        print(test_vars["keys"][0]["key_str"])
-        log.debug("Method: %s" % ably.auth.auth_method)
+
+        ably = AblyRest(Options.with_key('mykey.myvalue:mySecRet'))
         self.assertEqual(Auth.Method.BASIC, ably.auth.auth_method,
-                msg="Unexpected Auth method mismatch")
+            msg="Unexpected Auth method mismatch")
 
     def test_auth_init_token_only(self):
-        options = {
-            "auth_token": "this_is_not_really_a_token",
-        }
-
         ably = AblyRest(Options(auth_token="this_is_not_really_a_token"))
-
         self.assertEqual(Auth.Method.TOKEN, ably.auth.auth_method,
-                msg="Unexpected Auth method mismatch")
+            msg="Unexpected Auth method mismatch")
 
+    @responses.activate
     def test_auth_init_with_token_callback(self):
-        callback_called = []
-
-        def token_callback(**params):
-            callback_called.append(True)
-            return "this_is_not_really_a_token_request"
-
-        options = Options()
-        options.key_id = test_vars["keys"][0]["key_id"]
-        options.host = test_vars["host"]
-        options.port = test_vars["port"]
-        options.tls_port = test_vars["tls_port"]
-        options.tls = test_vars["tls"]
-        options.auth_callback = token_callback
+        options = Options(key_id='mykey.myvalue')
+        options.auth_callback = mock.MagicMock()
+        self._add_stats_responses()
 
         ably = AblyRest(options)
-
         try:
             ably.stats(None)
-        except:
+        except AblyException:
             pass
 
-        self.assertTrue(callback_called, msg="Token callback not called")
+        options.auth_callback.assert_called_once_with(client_id=None)
         self.assertEqual(Auth.Method.TOKEN, ably.auth.auth_method,
                 msg="Unexpected Auth method mismatch")
-        
+
     def test_auth_init_with_key_and_client_id(self):
-        options = Options.with_key(test_vars["keys"][0]["key_str"])
+        options = Options.with_key('mykey.myvalue:mySecRet')
         options.client_id = "testClientId"
 
         ably = AblyRest(options)
@@ -71,8 +84,7 @@ class TestAuth(unittest.TestCase):
                 msg="Unexpected Auth method mismatch")
 
     def test_auth_init_with_token(self):
-        options = Options(host=test_vars["host"], port=test_vars["port"],
-            tls_port=test_vars["tls_port"], tls=test_vars["tls"])
+        options = Options(host='example.com', port=80, tls_port=123, tls='tls.example.com')
 
         ably = AblyRest(options)
 

--- a/test/api_responses/stats.json
+++ b/test/api_responses/stats.json
@@ -1,0 +1,1116 @@
+[
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:18:10"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"apiRequests": {
+			"succeeded": 1
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:18:09"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:18:08"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"apiRequests": {
+			"succeeded": 1
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:18:07"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:18:06"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:18:05"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:18:04"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:18:03"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:18:02"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:18:01"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:18:00"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:59"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:58"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:57"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"apiRequests": {
+			"succeeded": 1
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:56"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"apiRequests": {
+			"succeeded": 2
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:55"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:54"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:53"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:52"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:51"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:50"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:49"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"apiRequests": {
+			"succeeded": 2
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:48"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:47"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"apiRequests": {
+			"succeeded": 4
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:46"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:45"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"apiRequests": {
+			"succeeded": 1
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:44"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"apiRequests": {
+			"succeeded": 1
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:43"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"apiRequests": {
+			"succeeded": 1
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:42"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:41"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"apiRequests": {
+			"succeeded": 1
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:40"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:39"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:38"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:37"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:36"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:35"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:34"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:33"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:32"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:31"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:30"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:29"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:28"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:27"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:26"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:25"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"apiRequests": {
+			"succeeded": 1
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:24"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			},
+			"all": {
+				"peak": 1,
+				"min": 1,
+				"mean": 1
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 3,
+			"mean": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:23"
+	},
+	{
+		"connections": {
+			"tls": {
+				"peak": 1,
+				"min": 0,
+				"mean": 0.6666666666666666,
+				"opened": 2
+			},
+			"all": {
+				"peak": 1,
+				"min": 0,
+				"mean": 0.6666666666666666,
+				"opened": 2
+			}
+		},
+		"channels": {
+			"peak": 3,
+			"min": 0,
+			"mean": 2,
+			"opened": 3
+		},
+		"count": 0,
+		"unit": "minute",
+		"intervalId": "2015-05-12:17:22"
+	}
+]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,10 @@
 [tox]
-envlist = py26,py27,py31,py32,py33
+envlist = py26, py27, py31, py32, py33, py34
+
 [testenv]
-deps=
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}/ably
+commands = python setup.py test
+deps =
     nose
-    -rrequirements.txt
-commands=nosetests
+    -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Hello,

Here are a few improvements for the Python package.

* First of all, I've used cookiecutter template to add some RST files, update setup.py, Makefile, travis.yml etc. (see https://github.com/audreyr/cookiecutter-pypackage)
* I've rewritten one of the test files to make it independent from Ably server infrastructure.

The testing approach used in the package requires existence and connection to a server. This isn't best practice, because:

* tests are not deterministic, and may fail just because of poor Internet connection;
* running tests requires a lot of time;
* the repository is not self-contained, information about expected responses is missing.

It's generally better to isolate the library from the outside world during testing, and use dumps of expected responses stored as files instead of querying them via HTTP. It's also easy to track changes in the API, as the dumps are required to be updated.

What do you think about it?

I've also looked at the library code, and I think it can be simplified a lot!

Cheers,

David