### PR TITLE
Rsc1 api constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,15 @@ ably.channels.foo.presence()
 
 ### Credentials
 
-You can provide either a `key` string or `app_id` + `key_id` + `key_value`
-combination.
+You can provide either a `key`, a `token` or, if you need more flexibility,
+with an `Option` object.
 
 ```python
 ably = AblyRest("key-string")
 ```
+
 or
 
 ```python
-ably = AblyRest(app_id="app-id", key_id="key-id", key_value="key-value")
+ably = AblyRest(token="app-token")
 ```

--- a/README.md
+++ b/README.md
@@ -61,15 +61,18 @@ ably.channels.foo.presence()
 
 ### Credentials
 
-You can provide either a `key`, a `token` or, if you need more flexibility,
-with an `Option` object.
+You can provide either a `key`, a `token` or, attributes to the `Options` object.
 
 ```python
-ably = AblyRest("key-string")
+ably = AblyRest("api:key")
 ```
 
 or
 
 ```python
-ably = AblyRest(token="app-token")
+AblyRest(token="token.string")
+```
+
+```python
+AblyRest(key="api:key", host="custom.host", port=8080)
 ```

--- a/ably/rest/rest.py
+++ b/ably/rest/rest.py
@@ -26,7 +26,7 @@ class AblyRest(object):
           - `key`: a valid key string
 
           **Or**
-          - `token`: Your Ably key id
+          - `token`: a valid token string
 
           **Optional Parameters**
           - `client_id`: Undocumented
@@ -52,9 +52,8 @@ class AblyRest(object):
                 options.auth_token = token
         elif options is None or not (options.auth_callback or options.auth_url or
                                      options.key_value or options.auth_token):
-            # TODO: what's the pattern for error codes?
-            raise AblyException("No authentication information provided",
-                                0, 0)
+            raise AblyException("Must include valid auth parameters",
+                                400, 40000)
 
         self.__client_id = options.client_id
 

--- a/ably/types/authoptions.py
+++ b/ably/types/authoptions.py
@@ -8,29 +8,27 @@ from ably.util.exceptions import AblyException
 class AuthOptions(object):
     def __init__(self, auth_callback=None, auth_url=None, auth_token=None,
                  auth_headers=None, auth_params=None, key_id=None, key_value=None,
-                 query_time=False):
+                 key=None, query_time=False):
         self.__auth_callback = auth_callback
         self.__auth_url = auth_url
         self.__auth_token = auth_token
         self.__auth_headers = auth_headers
         self.__auth_params = auth_params
-        self.__key_id = key_id
-        self.__key_value = key_value
+        if key is not None:
+            self.__key_id, self.__key_value = self.parse_key(key)
+        else:
+            self.__key_id = key_id
+            self.__key_value = key_value
         self.__query_time = query_time
 
-    @classmethod
-    def with_key(cls, key, **kwargs):
-        kwargs = kwargs or {}
-
-        key_components = key.split(':')
-
-        if len(key_components) != 2:
-            raise AblyException("invalid key parameter", 401, 40101)
-
-        kwargs['key_id'] = key_components[0]
-        kwargs['key_value'] = key_components[1]
-
-        return cls(**kwargs)
+    def parse_key(self, key):
+        try:
+            key_id, key_value = key.split(':')
+            return key_id, key_value
+        except ValueError:
+            raise AblyException("key of not len 2 parameters: {0}"
+                                .format(key.split(':')),
+                                401, 40101)
 
     def merge(self, other):
         if self.__auth_callback is None:

--- a/ably/types/authoptions.py
+++ b/ably/types/authoptions.py
@@ -7,7 +7,7 @@ from ably.util.exceptions import AblyException
 
 class AuthOptions(object):
     def __init__(self, auth_callback=None, auth_url=None, auth_token=None,
-                 auth_headers=None, auth_params=None, key_id=None, key_value=None,
+                 auth_headers=None, auth_params=None, key_name=None, key_secret=None,
                  key=None, query_time=False):
         self.__auth_callback = auth_callback
         self.__auth_url = auth_url
@@ -15,16 +15,16 @@ class AuthOptions(object):
         self.__auth_headers = auth_headers
         self.__auth_params = auth_params
         if key is not None:
-            self.__key_id, self.__key_value = self.parse_key(key)
+            self.__key_name, self.__key_secret = self.parse_key(key)
         else:
-            self.__key_id = key_id
-            self.__key_value = key_value
+            self.__key_name = key_name
+            self.__key_secret = key_secret
         self.__query_time = query_time
 
     def parse_key(self, key):
         try:
-            key_id, key_value = key.split(':')
-            return key_id, key_value
+            key_name, key_secret = key.split(':')
+            return key_name, key_secret
         except ValueError:
             raise AblyException("key of not len 2 parameters: {0}"
                                 .format(key.split(':')),
@@ -37,11 +37,11 @@ class AuthOptions(object):
         if self.__auth_url is None:
             self.__auth_url = other.auth_url
 
-        if self.__key_id is None:
-            self.__key_id = other.key_id
+        if self.__key_name is None:
+            self.__key_name = other.key_name
 
-        if self.__key_value is None:
-            self.__key_value = other.key_value
+        if self.__key_secret is None:
+            self.__key_secret = other.key_secret
 
         if self.__auth_token is None:
             self.__auth_token = other.auth_token
@@ -71,20 +71,20 @@ class AuthOptions(object):
         self.__auth_url = value
 
     @property
-    def key_id(self):
-        return self.__key_id
+    def key_name(self):
+        return self.__key_name
 
-    @key_id.setter
-    def key_id(self, value):
-        self.__key_id = value
+    @key_name.setter
+    def key_name(self, value):
+        self.__key_name = value
 
     @property
-    def key_value(self):
-        return self.__key_value
+    def key_secret(self):
+        return self.__key_secret
 
-    @key_value.setter
-    def key_value(self, value):
-        self.__key_value = value
+    @key_secret.setter
+    def key_secret(self, value):
+        self.__key_secret = value
 
     @property
     def auth_token(self):

--- a/ably/types/options.py
+++ b/ably/types/options.py
@@ -23,22 +23,6 @@ class Options(AuthOptions):
         self.__queue_messages = queue_messages
         self.__recover = recover
 
-    @classmethod
-    def with_key(cls, key, **kwargs):
-        kwargs = kwargs or {}
-
-        key_components = key.split(':')
-
-        if len(key_components) != 2:
-            raise AblyException("key of not len 2 parameters: {0}"
-                                .format(key.split(':')),
-                                401, 40101)
-
-        kwargs['key_id'] = key_components[0]
-        kwargs['key_value'] = key_components[1]
-
-        return cls(**kwargs)
-
     @property
     def client_id(self):
         return self.__client_id

--- a/test/ably/restappstats_test.py
+++ b/test/ably/restappstats_test.py
@@ -27,11 +27,11 @@ class TestRestAppStats(unittest.TestCase):
     def setUpClass(cls):
         log.debug("KEY class: "+test_vars["keys"][0]["key_str"])
         log.debug("TLS: "+str(test_vars["tls"]))
-        cls.ably = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"],
-                host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"]))
+        cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                            options=Options(host=test_vars["host"],
+                                            port=test_vars["port"],
+                                            tls_port=test_vars["tls_port"],
+                                            tls=test_vars["tls"]))
         time_from_service = cls.ably.time()
         cls.time_offset = time_from_service / 1000.0 - time.time()
 

--- a/test/ably/restappstats_test.py
+++ b/test/ably/restappstats_test.py
@@ -28,10 +28,10 @@ class TestRestAppStats(unittest.TestCase):
         log.debug("KEY class: "+test_vars["keys"][0]["key_str"])
         log.debug("TLS: "+str(test_vars["tls"]))
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                            options=Options(host=test_vars["host"],
-                                            port=test_vars["port"],
-                                            tls_port=test_vars["tls_port"],
-                                            tls=test_vars["tls"]))
+                            host=test_vars["host"],
+                            port=test_vars["port"],
+                            tls_port=test_vars["tls_port"],
+                            tls=test_vars["tls"])
         time_from_service = cls.ably.time()
         cls.time_offset = time_from_service / 1000.0 - time.time()
 

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import logging
 import unittest
-import os 
 
 from ably import AblyRest
 from ably import Auth
@@ -16,24 +15,19 @@ test_vars = RestSetup.get_test_vars()
 
 log = logging.getLogger(__name__)
 
+
 class TestAuth(unittest.TestCase):
+
     def test_auth_init_key_only(self):
-        
-        ably = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"]))
-        print(test_vars["keys"][0]["key_str"])
-        log.debug("Method: %s" % ably.auth.auth_method)
+        ably = AblyRest(key=test_vars["keys"][0]["key_str"])
         self.assertEqual(Auth.Method.BASIC, ably.auth.auth_method,
-                msg="Unexpected Auth method mismatch")
+                         msg="Unexpected Auth method mismatch")
 
     def test_auth_init_token_only(self):
-        options = {
-            "auth_token": "this_is_not_really_a_token",
-        }
-
-        ably = AblyRest(Options(auth_token="this_is_not_really_a_token"))
+        ably = AblyRest(token="this_is_not_really_a_token")
 
         self.assertEqual(Auth.Method.TOKEN, ably.auth.auth_method,
-                msg="Unexpected Auth method mismatch")
+                         msg="Unexpected Auth method mismatch")
 
     def test_auth_init_with_token_callback(self):
         callback_called = []
@@ -50,7 +44,7 @@ class TestAuth(unittest.TestCase):
         options.tls = test_vars["tls"]
         options.auth_callback = token_callback
 
-        ably = AblyRest(options)
+        ably = AblyRest(options=options)
 
         try:
             ably.stats(None)
@@ -62,10 +56,10 @@ class TestAuth(unittest.TestCase):
                 msg="Unexpected Auth method mismatch")
         
     def test_auth_init_with_key_and_client_id(self):
-        options = Options.with_key(test_vars["keys"][0]["key_str"])
+        options = Options(key=test_vars["keys"][0]["key_str"])
         options.client_id = "testClientId"
 
-        ably = AblyRest(options)
+        ably = AblyRest(options=options)
 
         self.assertEqual(Auth.Method.TOKEN, ably.auth.auth_method,
                 msg="Unexpected Auth method mismatch")
@@ -74,7 +68,8 @@ class TestAuth(unittest.TestCase):
         options = Options(host=test_vars["host"], port=test_vars["port"],
             tls_port=test_vars["tls_port"], tls=test_vars["tls"])
 
-        ably = AblyRest(options)
+        ably = AblyRest(token="this_is_not_really_a_token",
+                        options=options)
 
         self.assertEqual(Auth.Method.TOKEN, ably.auth.auth_method,
                 msg="Unexpected Auth method mismatch")

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -36,15 +36,12 @@ class TestAuth(unittest.TestCase):
             callback_called.append(True)
             return "this_is_not_really_a_token_request"
 
-        options = Options()
-        options.key_id = test_vars["keys"][0]["key_id"]
-        options.host = test_vars["host"]
-        options.port = test_vars["port"]
-        options.tls_port = test_vars["tls_port"]
-        options.tls = test_vars["tls"]
-        options.auth_callback = token_callback
-
-        ably = AblyRest(options=options)
+        ably = AblyRest(key_name=test_vars["keys"][0]["key_name"],
+                        host=test_vars["host"],
+                        port=test_vars["port"],
+                        tls_port=test_vars["tls_port"],
+                        tls=test_vars["tls"],
+                        auth_callback= token_callback)
 
         try:
             ably.stats(None)
@@ -57,19 +54,19 @@ class TestAuth(unittest.TestCase):
         
     def test_auth_init_with_key_and_client_id(self):
         options = Options(key=test_vars["keys"][0]["key_str"])
-        options.client_id = "testClientId"
 
-        ably = AblyRest(options=options)
+        ably = AblyRest(key=test_vars["keys"][0]["key_str"], client_id='testClientId')
 
         self.assertEqual(Auth.Method.TOKEN, ably.auth.auth_method,
                 msg="Unexpected Auth method mismatch")
 
     def test_auth_init_with_token(self):
-        options = Options(host=test_vars["host"], port=test_vars["port"],
-            tls_port=test_vars["tls_port"], tls=test_vars["tls"])
 
         ably = AblyRest(token="this_is_not_really_a_token",
-                        options=options)
+                        host=test_vars["host"],
+                        port=test_vars["port"],
+                        tls_port=test_vars["tls_port"],
+                        tls=test_vars["tls"])
 
         self.assertEqual(Auth.Method.TOKEN, ably.auth.auth_method,
                 msg="Unexpected Auth method mismatch")

--- a/test/ably/restcapability_test.py
+++ b/test/ably/restcapability_test.py
@@ -21,11 +21,11 @@ test_vars = RestSetup.get_test_vars()
 class TestRestCapability(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.ably = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"],
-                host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"]))
+        cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                            options=Options(host=test_vars["host"],
+                                            port=test_vars["port"],
+                                            tls_port=test_vars["tls_port"],
+                                            tls=test_vars["tls"]))
 
     @property
     def ably(self):

--- a/test/ably/restcapability_test.py
+++ b/test/ably/restcapability_test.py
@@ -22,10 +22,10 @@ class TestRestCapability(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                            options=Options(host=test_vars["host"],
-                                            port=test_vars["port"],
-                                            tls_port=test_vars["tls_port"],
-                                            tls=test_vars["tls"]))
+                            host=test_vars["host"],
+                            port=test_vars["port"],
+                            tls_port=test_vars["tls_port"],
+                            tls=test_vars["tls"])
 
     @property
     def ably(self):
@@ -33,8 +33,8 @@ class TestRestCapability(unittest.TestCase):
 
     def test_blanket_intersection_with_key(self):
         key = test_vars['keys'][1]
-        token_details = self.ably.auth.request_token(key_id=key['key_id'],
-                                                     key_value=key['key_value'])
+        token_details = self.ably.auth.request_token(key_name=key['key_name'],
+                                                     key_secret=key['key_secret'])
         expected_capability = Capability(key["capability"])
         self.assertIsNotNone(token_details.token, msg="Expected token")
         self.assertEqual(expected_capability, token_details.capability,
@@ -42,13 +42,13 @@ class TestRestCapability(unittest.TestCase):
 
     def test_equal_intersection_with_key(self):
         key = test_vars['keys'][1]
-        
+
         token_params = {
             "capability": key["capability"],
         }
 
-        token_details = self.ably.auth.request_token(key_id=key['key_id'],
-                key_value=key['key_value'], 
+        token_details = self.ably.auth.request_token(key_name=key['key_name'],
+                key_secret=key['key_secret'],
                 token_params=token_params)
 
         expected_capability = Capability(key["capability"])
@@ -59,38 +59,38 @@ class TestRestCapability(unittest.TestCase):
 
     def test_empty_ops_intersection(self):
         key = test_vars['keys'][1]
-        
+
         token_params = {
             "capability": {
                 "testchannel": ["subscribe"],
             },
         }
 
-        self.assertRaises(AblyException, self.ably.auth.request_token, 
-                key_id=key['key_id'],
-                key_value=key['key_value'], 
+        self.assertRaises(AblyException, self.ably.auth.request_token,
+                key_name=key['key_name'],
+                key_secret=key['key_secret'],
                 token_params=token_params)
 
     def test_empty_paths_intersection(self):
         key = test_vars['keys'][1]
-        
+
         token_params = {
             "capability": {
                 "testchannelx": ["publish"],
             },
         }
 
-        self.assertRaises(AblyException, self.ably.auth.request_token, 
-                key_id=key['key_id'],
-                key_value=key['key_value'], 
+        self.assertRaises(AblyException, self.ably.auth.request_token,
+                key_name=key['key_name'],
+                key_secret=key['key_secret'],
                 token_params=token_params)
 
     def test_non_empty_ops_intersection(self):
         key = test_vars['keys'][4]
-        
+
         kwargs = {
-            "key_id": key["key_id"],
-            "key_value": key["key_value"],
+            "key_name": key["key_name"],
+            "key_secret": key["key_secret"],
             "token_params": {
                 "capability": {
                     "channel2": ["presence", "subscribe"],
@@ -110,10 +110,11 @@ class TestRestCapability(unittest.TestCase):
 
     def test_non_empty_paths_intersection(self):
         key = test_vars['keys'][4]
-        
+
         kwargs = {
-            "key_id": key["key_id"],
-            "key_value": key["key_value"],
+            "key_name": key["key_name"],
+
+            "key_secret": key["key_secret"],
             "token_params": {
                 "capability": {
                     "channel2": ["presence", "subscribe"],
@@ -134,10 +135,10 @@ class TestRestCapability(unittest.TestCase):
 
     def test_wildcard_ops_intersection(self):
         key = test_vars['keys'][4]
-        
+
         kwargs = {
-            "key_id": key["key_id"],
-            "key_value": key["key_value"],
+            "key_name": key["key_name"],
+            "key_secret": key["key_secret"],
             "token_params": {
                 "capability": {
                     "channel2": ["*"],
@@ -157,10 +158,10 @@ class TestRestCapability(unittest.TestCase):
 
     def test_wildcard_ops_intersection_2(self):
         key = test_vars['keys'][4]
-        
+
         kwargs = {
-            "key_id": key["key_id"],
-            "key_value": key["key_value"],
+            "key_name": key["key_name"],
+            "key_secret": key["key_secret"],
             "token_params": {
                 "capability": {
                     "channel6": ["publish", "subscribe"],
@@ -180,10 +181,10 @@ class TestRestCapability(unittest.TestCase):
 
     def test_wildcard_resources_intersection(self):
         key = test_vars['keys'][2]
-        
+
         kwargs = {
-            "key_id": key["key_id"],
-            "key_value": key["key_value"],
+            "key_name": key["key_name"],
+            "key_secret": key["key_secret"],
             "token_params": {
                 "capability": {
                     "cansubscribe": ["subscribe"],
@@ -205,8 +206,8 @@ class TestRestCapability(unittest.TestCase):
         key = test_vars['keys'][2]
 
         kwargs = {
-            "key_id": key["key_id"],
-            "key_value": key["key_value"],
+            "key_name": key["key_name"],
+            "key_secret": key["key_secret"],
             "token_params": {
                 "capability": {
                     "cansubscribe:check": ["subscribe"],
@@ -226,10 +227,10 @@ class TestRestCapability(unittest.TestCase):
 
     def test_wildcard_resources_intersection_3(self):
         key = test_vars['keys'][2]
-        
+
         kwargs = {
-            "key_id": key["key_id"],
-            "key_value": key["key_value"],
+            "key_name": key["key_name"],
+            "key_secret": key["key_secret"],
             "token_params": {
                 "capability": {
                     "cansubscribe:*": ["subscribe"],
@@ -284,7 +285,7 @@ class TestRestCapability(unittest.TestCase):
         capability = Capability({
             "channel0": []
         })
-        
+
         kwargs = {
             "token_params": {
                 "capability": {

--- a/test/ably/restchannelhistory_test.py
+++ b/test/ably/restchannelhistory_test.py
@@ -23,11 +23,11 @@ log = logging.getLogger(__name__)
 class TestRestChannelHistory(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.ably = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"],
-                host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"]))
+        cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                            options=Options(host=test_vars["host"],
+                                            port=test_vars["port"],
+                                            tls_port=test_vars["tls_port"],
+                                            tls=test_vars["tls"]))
         cls.time_offset = cls.ably.time() - int(time.time())
 
     @property

--- a/test/ably/restchannelhistory_test.py
+++ b/test/ably/restchannelhistory_test.py
@@ -24,10 +24,10 @@ class TestRestChannelHistory(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                            options=Options(host=test_vars["host"],
-                                            port=test_vars["port"],
-                                            tls_port=test_vars["tls_port"],
-                                            tls=test_vars["tls"]))
+                            host=test_vars["host"],
+                            port=test_vars["port"],
+                            tls_port=test_vars["tls_port"],
+                            tls=test_vars["tls"])
         cls.time_offset = cls.ably.time() - int(time.time())
 
     @property

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -22,19 +22,19 @@ log = logging.getLogger(__name__)
 class TestRestChannelPublish(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.ably = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"],
-                host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"],
-                use_text_protocol=True))
+        cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                            options=Options(host=test_vars["host"],
+                                            port=test_vars["port"],
+                                            tls_port=test_vars["tls_port"],
+                                            tls=test_vars["tls"],
+                                            use_text_protocol=True))
 
-        cls.ably_binary = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"],
-                host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"],
-                use_text_protocol=False))
+        cls.ably_binary = AblyRest(key=test_vars["keys"][0]["key_str"],
+                                   options=Options(host=test_vars["host"],
+                                                   port=test_vars["port"],
+                                                   tls_port=test_vars["tls_port"],
+                                                   tls=test_vars["tls"],
+                                                   use_text_protocol=False))
 
     def test_publish_various_datatypes_text(self):
         publish0 = TestRestChannelPublish.ably.channels["persisted:publish0"]

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -23,18 +23,18 @@ class TestRestChannelPublish(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                            options=Options(host=test_vars["host"],
-                                            port=test_vars["port"],
-                                            tls_port=test_vars["tls_port"],
-                                            tls=test_vars["tls"],
-                                            use_text_protocol=True))
+                            host=test_vars["host"],
+                            port=test_vars["port"],
+                            tls_port=test_vars["tls_port"],
+                            tls=test_vars["tls"],
+                            use_text_protocol=True)
 
         cls.ably_binary = AblyRest(key=test_vars["keys"][0]["key_str"],
-                                   options=Options(host=test_vars["host"],
-                                                   port=test_vars["port"],
-                                                   tls_port=test_vars["tls_port"],
-                                                   tls=test_vars["tls"],
-                                                   use_text_protocol=False))
+                                   host=test_vars["host"],
+                                   port=test_vars["port"],
+                                   tls_port=test_vars["tls_port"],
+                                   tls=test_vars["tls"],
+                                   use_text_protocol=False)
 
     def test_publish_various_datatypes_text(self):
         publish0 = TestRestChannelPublish.ably.channels["persisted:publish0"]

--- a/test/ably/restchannels_test.py
+++ b/test/ably/restchannels_test.py
@@ -18,11 +18,11 @@ test_vars = RestSetup.get_test_vars()
 class TestChannels(unittest.TestCase):
 
     def setUp(self):
-        self.ably = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"],
+        self.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
                              host=test_vars["host"],
                              port=test_vars["port"],
                              tls_port=test_vars["tls_port"],
-                             tls=test_vars["tls"]))
+                             tls=test_vars["tls"])
 
     def test_rest_channels_attr(self):
         self.assertTrue(hasattr(self.ably, 'channels'))

--- a/test/ably/restcrypto_test.py
+++ b/test/ably/restcrypto_test.py
@@ -22,14 +22,14 @@ log = logging.getLogger(__name__)
 class TestRestCrypto(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        options = Options.with_key(test_vars["keys"][0]["key_str"],
-                host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"],
-                use_text_protocol=True)
-        cls.ably = AblyRest(options)
-        cls.ably2 = AblyRest(options)
+        options = Options(key=test_vars["keys"][0]["key_str"],
+                          host=test_vars["host"],
+                          port=test_vars["port"],
+                          tls_port=test_vars["tls_port"],
+                          tls=test_vars["tls"],
+                          use_text_protocol=True)
+        cls.ably = AblyRest(options=options)
+        cls.ably2 = AblyRest(options=options)
 
     def test_cbc_channel_cipher(self):
         key = six.b(

--- a/test/ably/restcrypto_test.py
+++ b/test/ably/restcrypto_test.py
@@ -22,14 +22,16 @@ log = logging.getLogger(__name__)
 class TestRestCrypto(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        options = Options(key=test_vars["keys"][0]["key_str"],
-                          host=test_vars["host"],
-                          port=test_vars["port"],
-                          tls_port=test_vars["tls_port"],
-                          tls=test_vars["tls"],
-                          use_text_protocol=True)
-        cls.ably = AblyRest(options=options)
-        cls.ably2 = AblyRest(options=options)
+        options = {
+            "key": test_vars["keys"][0]["key_str"],
+            "host": test_vars["host"],
+            "port": test_vars["port"],
+            "tls_port": test_vars["tls_port"],
+            "tls": test_vars["tls"],
+            "use_text_protocol": True
+        }
+        cls.ably = AblyRest(**options)
+        cls.ably2 = AblyRest(**options)
 
     def test_cbc_channel_cipher(self):
         key = six.b(
@@ -53,7 +55,7 @@ class TestRestCrypto(unittest.TestCase):
                 '\xdf\x7f\x6e\x38\x17\x4a\xff\x50'
                 '\x73\x23\xbb\xca\x16\xb0\xe2\x84'
         )
-        
+
         actual_ciphertext = cipher.encrypt(plaintext)
 
         self.assertEqual(expected_ciphertext, actual_ciphertext)
@@ -153,10 +155,10 @@ class TestRestCrypto(unittest.TestCase):
         publish0.publish("publish6", ["This is a JSONArray message payload"])
 
         rx_channel = TestRestCrypto.ably2.channels.get("persisted:crypto_publish_key_mismatch", channel_options)
-        
+
         try:
             with self.assertRaises(AblyException) as cm:
-                messages = rx_channel.history()                
+                messages = rx_channel.history()
         except Exception as e:
             log.debug('test_crypto_publish_key_mismatch_fail: rx_channel.history not creating exception')
             log.debug(messages.current[0].data)

--- a/test/ably/restinit_test.py
+++ b/test/ably/restinit_test.py
@@ -14,36 +14,68 @@ test_vars = RestSetup.get_test_vars()
 
 class TestRestInit(unittest.TestCase):
     def test_key_only(self):
-        AblyRest(Options.with_key(test_vars["keys"][0]["key_str"]))
+        ably = AblyRest(key=test_vars["keys"][0]["key_str"])
+        self.assertEqual(ably.options.key_id, test_vars["keys"][0]["key_id"],
+                         "Key id does not match")
+        self.assertEqual(ably.options.key_value, test_vars["keys"][0]["key_value"],
+                         "Key value does not match")
 
     def test_key_in_options(self):
-        AblyRest(Options.with_key(test_vars["keys"][0]["key_str"]))
+        ably = AblyRest(options=Options(key=test_vars["keys"][0]["key_str"]))
+        self.assertEqual(ably.options.key_id, test_vars["keys"][0]["key_id"],
+                         "Key id does not match")
+        self.assertEqual(ably.options.key_value, test_vars["keys"][0]["key_value"],
+                         "Key value does not match")
+
+    def test_token_in_options(self):
+        ably = AblyRest(options=Options(auth_token='foo'))
+        self.assertEqual(ably.options.auth_token, 'foo',
+                         "Token not set at options")
+
+    def test_with_token(self):
+        ably = AblyRest(token='foo')
+        self.assertEqual(ably.options.auth_token, 'foo',
+                         "Token not set at options")
+
+    def test_with_options_token_callback(self):
+        def token_callback(**params):
+            return "this_is_not_really_a_token_request"
+        AblyRest(options=Options(auth_callback=token_callback))
+
+    def test_with_options_auth_url(self):
+        AblyRest(options=Options(auth_url='not_really_an_url'))
 
     def test_specified_host(self):
-        ably = AblyRest(Options(host="some.other.host"))
-        self.assertEqual("some.other.host", ably.options.host, 
-                msg="Unexpected host mismatch")
+        ably = AblyRest(token='foo', options=Options(host="some.other.host"))
+        self.assertEqual("some.other.host", ably.options.host,
+                         msg="Unexpected host mismatch")
 
     def test_specified_port(self):
-        ably = AblyRest(Options(port=9998, tls_port=9999))
+        ably = AblyRest(token='foo', options=Options(port=9998, tls_port=9999))
         self.assertEqual(9999, Defaults.get_port(ably.options),
-                msg="Unexpected port mismatch. Expected: 9999. Actual: %d" % ably.options.tls_port)
+                         msg="Unexpected port mismatch. Expected: 9999. Actual: %d" %
+                         ably.options.tls_port)
 
     def test_tls_defaults_to_true(self):
-        ably = AblyRest()
+        ably = AblyRest(token='foo')
         self.assertTrue(ably.options.tls,
-                msg="Expected encryption to default to true")
+                        msg="Expected encryption to default to true")
         self.assertEqual(Defaults.tls_port, Defaults.get_port(ably.options),
-                msg="Unexpected port mismatch")
+                         msg="Unexpected port mismatch")
 
     def test_tls_can_be_disabled(self):
-        ably = AblyRest(Options(tls=False))
+        ably = AblyRest(token='foo', options=Options(tls=False))
         self.assertFalse(ably.options.tls,
-                msg="Expected encryption to be False")
+                         msg="Expected encryption to be False")
         self.assertEqual(Defaults.port, Defaults.get_port(ably.options),
-                msg="Unexpected port mismatch")
+                         msg="Unexpected port mismatch")
+
+    def test_with_no_params(self):
+        self.assertRaises(AblyException, AblyRest)
+
+    def test_with_no_auth_params(self):
+        self.assertRaises(AblyException, AblyRest, options=Options(port=111))
 
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/test/ably/restinit_test.py
+++ b/test/ably/restinit_test.py
@@ -4,7 +4,6 @@ import unittest
 
 from ably import AblyRest
 from ably import AblyException
-from ably import Options
 from ably.transport.defaults import Defaults
 
 from test.ably.restsetup import RestSetup
@@ -15,43 +14,52 @@ test_vars = RestSetup.get_test_vars()
 class TestRestInit(unittest.TestCase):
     def test_key_only(self):
         ably = AblyRest(key=test_vars["keys"][0]["key_str"])
-        self.assertEqual(ably.options.key_id, test_vars["keys"][0]["key_id"],
+        self.assertEqual(ably.options.key_name, test_vars["keys"][0]["key_name"],
                          "Key id does not match")
-        self.assertEqual(ably.options.key_value, test_vars["keys"][0]["key_value"],
+        self.assertEqual(ably.options.key_secret, test_vars["keys"][0]["key_secret"],
                          "Key value does not match")
-
-    def test_key_in_options(self):
-        ably = AblyRest(options=Options(key=test_vars["keys"][0]["key_str"]))
-        self.assertEqual(ably.options.key_id, test_vars["keys"][0]["key_id"],
-                         "Key id does not match")
-        self.assertEqual(ably.options.key_value, test_vars["keys"][0]["key_value"],
-                         "Key value does not match")
-
-    def test_token_in_options(self):
-        ably = AblyRest(options=Options(auth_token='foo'))
-        self.assertEqual(ably.options.auth_token, 'foo',
-                         "Token not set at options")
 
     def test_with_token(self):
-        ably = AblyRest(token='foo')
-        self.assertEqual(ably.options.auth_token, 'foo',
+        ably = AblyRest(token="foo")
+        self.assertEqual(ably.options.auth_token, "foo",
                          "Token not set at options")
 
     def test_with_options_token_callback(self):
         def token_callback(**params):
             return "this_is_not_really_a_token_request"
-        AblyRest(options=Options(auth_callback=token_callback))
+        AblyRest(auth_callback=token_callback)
+
+    def test_ambiguous_key_raises_value_error(self):
+        self.assertRaisesRegexp(ValueError, "mutually exclusive", AblyRest,
+                                key=test_vars["keys"][0]["key_str"],
+                                key_name='x')
+        self.assertRaisesRegexp(ValueError, "mutually exclusive", AblyRest,
+                                key=test_vars["keys"][0]["key_str"],
+                                key_secret='x')
+
+    def test_with_key_name_or_secret_only(self):
+        self.assertRaisesRegexp(ValueError, "key is missing", AblyRest,
+                                key_name='x')
+        self.assertRaisesRegexp(ValueError, "key is missing", AblyRest,
+                                key_secret='x')
+
+    def test_with_key_name_and_secret(self):
+        ably = AblyRest(key_name="foo", key_secret="bar")
+        self.assertEqual(ably.options.key_name, "foo",
+                         "Key id does not match")
+        self.assertEqual(ably.options.key_secret, "bar",
+                         "Key value does not match")
 
     def test_with_options_auth_url(self):
-        AblyRest(options=Options(auth_url='not_really_an_url'))
+        AblyRest(auth_url='not_really_an_url')
 
     def test_specified_host(self):
-        ably = AblyRest(token='foo', options=Options(host="some.other.host"))
+        ably = AblyRest(token='foo', host="some.other.host")
         self.assertEqual("some.other.host", ably.options.host,
                          msg="Unexpected host mismatch")
 
     def test_specified_port(self):
-        ably = AblyRest(token='foo', options=Options(port=9998, tls_port=9999))
+        ably = AblyRest(token='foo', port=9998, tls_port=9999)
         self.assertEqual(9999, Defaults.get_port(ably.options),
                          msg="Unexpected port mismatch. Expected: 9999. Actual: %d" %
                          ably.options.tls_port)
@@ -64,17 +72,17 @@ class TestRestInit(unittest.TestCase):
                          msg="Unexpected port mismatch")
 
     def test_tls_can_be_disabled(self):
-        ably = AblyRest(token='foo', options=Options(tls=False))
+        ably = AblyRest(token='foo', tls=False)
         self.assertFalse(ably.options.tls,
                          msg="Expected encryption to be False")
         self.assertEqual(Defaults.port, Defaults.get_port(ably.options),
                          msg="Unexpected port mismatch")
 
     def test_with_no_params(self):
-        self.assertRaises(AblyException, AblyRest)
+        self.assertRaises(ValueError, AblyRest)
 
     def test_with_no_auth_params(self):
-        self.assertRaises(AblyException, AblyRest, options=Options(port=111))
+        self.assertRaises(ValueError, AblyRest, port=111)
 
 
 if __name__ == "__main__":

--- a/test/ably/restsetup.py
+++ b/test/ably/restsetup.py
@@ -35,10 +35,11 @@ else:
     tls_port = 8081
 
 
-ably = AblyRest(Options(host=host,
-        port=port,
-        tls_port=tls_port,
-        tls=tls))
+ably = AblyRest(token='not_a_real_token',
+                options=Options(host=host,
+                                port=port,
+                                tls_port=tls_port,
+                                tls=tls))
 
 
 class RestSetup:
@@ -77,12 +78,12 @@ class RestSetup:
     @staticmethod
     def clear_test_vars():
         test_vars = RestSetup.__test_vars
-        options = Options.with_key(test_vars["keys"][0]["key_str"])
+        options = Options(key=test_vars["keys"][0]["key_str"])
         options.host = test_vars["host"]
         options.port = test_vars["port"]
         options.tls_port = test_vars["tls_port"]
         options.tls = test_vars["tls"]
-        ably = AblyRest(options)
+        ably = AblyRest(options=options)
 
         headers = HttpUtils.default_get_headers()
         ably.http.delete('/apps/' + test_vars['app_id'], headers)

--- a/test/ably/restsetup.py
+++ b/test/ably/restsetup.py
@@ -35,11 +35,9 @@ else:
     tls_port = 8081
 
 
-ably = AblyRest(token='not_a_real_token',
-                options=Options(host=host,
-                                port=port,
-                                tls_port=tls_port,
-                                tls=tls))
+ably = AblyRest(token='not_a_real_token', host=host,
+                port=port, tls_port=tls_port,
+                tls=tls)
 
 
 class RestSetup:
@@ -63,8 +61,8 @@ class RestSetup:
                 "tls_port": tls_port,
                 "tls": tls,
                 "keys": [{
-                    "key_id": "%s.%s" % (app_id, k.get("id", "")),
-                    "key_value": k.get("value", ""),
+                    "key_name": "%s.%s" % (app_id, k.get("id", "")),
+                    "key_secret": k.get("value", ""),
                     "key_str": "%s.%s:%s" % (app_id,  k.get("id", ""), k.get("value", "")),
                     "capability": Capability(json.loads(k.get("capability", "{}"))),
                 } for k in app_spec.get("keys", [])]
@@ -83,7 +81,11 @@ class RestSetup:
         options.port = test_vars["port"]
         options.tls_port = test_vars["tls_port"]
         options.tls = test_vars["tls"]
-        ably = AblyRest(options=options)
+        ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                        host = test_vars["host"],
+                        port = test_vars["port"],
+                        tls_port = test_vars["tls_port"],
+                        tls = test_vars["tls"])
 
         headers = HttpUtils.default_get_headers()
         ably.http.delete('/apps/' + test_vars['app_id'], headers)

--- a/test/ably/resttime_test.py
+++ b/test/ably/resttime_test.py
@@ -14,11 +14,11 @@ test_vars = RestSetup.get_test_vars()
 
 class TestRestTime(unittest.TestCase):
     def test_time_accuracy(self):
-        ably = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"],
-                host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"]))
+        ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                        options=Options(host=test_vars["host"],
+                                        port=test_vars["port"],
+                                        tls_port=test_vars["tls_port"],
+                                        tls=test_vars["tls"]))
 
         reported_time = ably.time()
         actual_time = time.time() * 1000.0
@@ -27,18 +27,18 @@ class TestRestTime(unittest.TestCase):
                 msg="Time is not within 2 seconds")
 
     def test_time_without_key_or_token(self):
-        ably = AblyRest(Options(host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"]))
+        ably = AblyRest(token='foo',
+                        options=Options(host=test_vars["host"],
+                                        port=test_vars["port"],
+                                        tls_port=test_vars["tls_port"],
+                                        tls=test_vars["tls"]))
 
         ably.time()
-    
+
     def test_time_fails_without_valid_host(self):
-        ably = AblyRest(Options(host="this.host.does.not.exist",
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"]))
+        ably = AblyRest(token='foo',
+                        options=Options(host="this.host.does.not.exist",
+                                        port=test_vars["port"],
+                                        tls_port=test_vars["tls_port"]))
 
         self.assertRaises(AblyException, ably.time)
-
-

--- a/test/ably/resttime_test.py
+++ b/test/ably/resttime_test.py
@@ -15,10 +15,10 @@ test_vars = RestSetup.get_test_vars()
 class TestRestTime(unittest.TestCase):
     def test_time_accuracy(self):
         ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                        options=Options(host=test_vars["host"],
-                                        port=test_vars["port"],
-                                        tls_port=test_vars["tls_port"],
-                                        tls=test_vars["tls"]))
+                        host=test_vars["host"],
+                        port=test_vars["port"],
+                        tls_port=test_vars["tls_port"],
+                        tls=test_vars["tls"])
 
         reported_time = ably.time()
         actual_time = time.time() * 1000.0
@@ -28,17 +28,17 @@ class TestRestTime(unittest.TestCase):
 
     def test_time_without_key_or_token(self):
         ably = AblyRest(token='foo',
-                        options=Options(host=test_vars["host"],
-                                        port=test_vars["port"],
-                                        tls_port=test_vars["tls_port"],
-                                        tls=test_vars["tls"]))
+                        host=test_vars["host"],
+                        port=test_vars["port"],
+                        tls_port=test_vars["tls_port"],
+                        tls=test_vars["tls"])
 
         ably.time()
 
     def test_time_fails_without_valid_host(self):
         ably = AblyRest(token='foo',
-                        options=Options(host="this.host.does.not.exist",
-                                        port=test_vars["port"],
-                                        tls_port=test_vars["tls_port"]))
+                        host="this.host.does.not.exist",
+                        port=test_vars["port"],
+                        tls_port=test_vars["tls_port"])
 
         self.assertRaises(AblyException, ably.time)

--- a/test/ably/resttoken_test.py
+++ b/test/ably/resttoken_test.py
@@ -25,11 +25,11 @@ class TestRestToken(unittest.TestCase):
     def setUp(self):
         capability = {"*":["*"]}
         self.permit_all = six.text_type(Capability(capability))
-        self.ably = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"],
-                host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"]))
+        self.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                             options=Options(host=test_vars["host"],
+                                             port=test_vars["port"],
+                                             tls_port=test_vars["tls_port"],
+                                             tls=test_vars["tls"]))
 
     def test_request_token_null_params(self):
         pre_time = self.server_time()

--- a/test/ably/resttoken_test.py
+++ b/test/ably/resttoken_test.py
@@ -26,10 +26,10 @@ class TestRestToken(unittest.TestCase):
         capability = {"*":["*"]}
         self.permit_all = six.text_type(Capability(capability))
         self.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                             options=Options(host=test_vars["host"],
-                                             port=test_vars["port"],
-                                             tls_port=test_vars["tls_port"],
-                                             tls=test_vars["tls"]))
+                             host=test_vars["host"],
+                             port=test_vars["port"],
+                             tls_port=test_vars["tls_port"],
+                             tls=test_vars["tls"])
 
     def test_request_token_null_params(self):
         pre_time = self.server_time()
@@ -117,8 +117,8 @@ class TestRestToken(unittest.TestCase):
 
     def test_request_token_with_specified_key(self):
         key = RestSetup.get_test_vars()["keys"][1]
-        token_details = self.ably.auth.request_token(key_id=key["key_id"],
-                key_value=key["key_value"])
+        token_details = self.ably.auth.request_token(key_name=key["key_name"],
+                key_secret=key["key_secret"])
         self.assertIsNotNone(token_details.token, msg="Expected token")
         self.assertEqual(key.get("capability"),
                 token_details.capability,


### PR DESCRIPTION
(RSC1) The constructor accepts either an API key, a token string, or a set of ClientOptions. An exception is raised if invalid arguments are provided such as no API key, token and no means to create a token.