### PR TITLE
RSL1a, RSL1b, RSL1e and RSL1c (incomplete)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ develop-eggs
 lib
 lib64
 __pycache__
+/.eggs/
 
 # Installer logs
 pip-log.txt
@@ -26,6 +27,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+/htmlcov/
 
 # Translations
 *.mo

--- a/ably/types/message.py
+++ b/ably/types/message.py
@@ -82,7 +82,7 @@ class Message(object):
 
         self.__data = decrypted_typed_buffer.decode()
 
-    def as_json(self):
+    def as_dict(self):
         data = self.data
         encoding = None
         data_type = None
@@ -112,8 +112,10 @@ class Message(object):
         if data_type:
             request_body['type'] = data_type
 
-        request_body = json.dumps(request_body)
         return request_body
+
+    def as_json(self):
+        return json.dumps(self.as_dict())
 
     @staticmethod
     def from_json(obj):
@@ -197,3 +199,11 @@ def make_encrypted_message_response_handler(cipher):
             message.decrypt(cipher)
         return messages
     return encrypted_message_response_handler
+
+
+class MessageJSONEncoder(json.JSONEncoder):
+    def default(self, message):
+        if isinstance(message, Message):
+            return message.as_dict()
+        else:
+            return json.JSONEncoder.default(self, message)

--- a/ably/types/message.py
+++ b/ably/types/message.py
@@ -87,8 +87,6 @@ class Message(object):
         encoding = None
         data_type = None
 
-        # log.debug(data.__class__)
-
         if isinstance(data, CipherData):
             data_type = data.type
             data = base64.b64encode(data.buffer).decode('ascii')
@@ -97,14 +95,13 @@ class Message(object):
             data = base64.b64encode(data).decode('ascii')
             encoding = 'base64'
 
-        # log.debug(data)
-        # log.debug(data.__class__)
-
         request_body = {
             'name': self.name,
             'data': data,
             'timestamp': self.timestamp or int(time.time() * 1000.0),
         }
+        request_body = {k: v for (k, v) in request_body.items()
+                        if v is not None}  # None values aren't included
 
         if encoding:
             request_body['encoding'] = encoding

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 msgpack-python==0.4.6
 pycrypto==2.6.1
-requests==2.6.0
+requests==2.7.0
 six==1.9.0
-#wsgiref==0.1.2,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-msgpack-python==0.4.6
-pycrypto==2.6.1
-requests==2.7.0
-six==1.9.0
+msgpack-python>=0.4.6
+pycrypto>=2.6.1
+requests>=2.7.0,<2.8
+six>=1.9.0

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,16 @@ from setuptools import setup
 
 setup(
     name='ably-python',
-    version='0.1dev',
+    version='0.1.dev',
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
     ],
     packages=['ably',],
-    install_requires=['requests>=1.0.0',],
+    install_requires=['msgpack-python>=0.4.6',
+                      'pycrypto>=2.6.1',
+                      'requests>=2.7.0,<2.8',
+                      'six>=1.9.0'],  # remember to update these on tox.ini!
+                                      # there's no easy way to reuse this.
     long_description='',
-    test_suite='nose.collector',
-    tests_require=['nose>=1.0.0',]
 )
-

--- a/test/ably/restappstats_test.py
+++ b/test/ably/restappstats_test.py
@@ -18,6 +18,7 @@ test_vars = RestSetup.get_test_vars()
 log.debug("KEY init: "+test_vars["keys"][0]["key_str"])
 
 
+@unittest.skip("stats not implemented")
 class TestRestAppStats(unittest.TestCase):
     test_start = 0
     interval_start = 0

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -70,34 +70,34 @@ class TestRestChannelPublish(unittest.TestCase):
                          message_contents["publish3"],
                          msg="Expect publish3 to be expected JSONObject")
 
-    # TODO: test messagepack later
-    # def test_publish_various_datatypes_binary(self):
-    #     publish1 = TestRestChannelPublish.ably_binary.channels.publish1
+    @unittest.skip("messagepack not implemented")
+    def test_publish_various_datatypes_binary(self):
+        publish1 = TestRestChannelPublish.ably_binary.channels.publish1
 
-    #     publish1.publish("publish0", "This is a string message payload")
-    #     publish1.publish("publish1", bytearray("This is a byte[] message payload", "utf_8"))
-    #     publish1.publish("publish2", {"test": "This is a JSONObject message payload"})
-    #     publish1.publish("publish3", ["This is a JSONArray message payload"])
+        publish1.publish("publish0", "This is a string message payload")
+        publish1.publish("publish1", bytearray("This is a byte[] message payload", "utf_8"))
+        publish1.publish("publish2", {"test": "This is a JSONObject message payload"})
+        publish1.publish("publish3", ["This is a JSONArray message payload"])
 
-    #     # Get the history for this channel
-    #     messages = publish1.history()
-    #     self.assertIsNotNone(messages, msg="Expected non-None messages")
-    #     self.assertEqual(4, len(messages), msg="Expected 4 messages")
+        # Get the history for this channel
+        messages = publish1.history()
+        self.assertIsNotNone(messages, msg="Expected non-None messages")
+        self.assertEqual(4, len(messages), msg="Expected 4 messages")
 
-    #     message_contents = dict((m.name, m.data) for m in messages)
+        message_contents = dict((m.name, m.data) for m in messages)
 
-    #     self.assertEqual("This is a string message payload",
-    #                      message_contents["publish0"],
-    #                      msg="Expect publish0 to be expected String)")
-    #     self.assertEqual("This is a byte[] message payload",
-    #                      message_contents["publish1"],
-    #                      msg="Expect publish1 to be expected byte[]")
-    #     self.assertEqual({"test": "This is a JSONObject message payload"},
-    #                      json.loads(message_contents["publish2"]),
-    #                      msg="Expect publish2 to be expected JSONObject")
-    #     self.assertEqual(["This is a JSONArray message payload"],
-    #                      json.loads(message_contents["publish3"]),
-    #                      msg="Expect publish3 to be expected JSONObject")
+        self.assertEqual("This is a string message payload",
+                         message_contents["publish0"],
+                         msg="Expect publish0 to be expected String)")
+        self.assertEqual("This is a byte[] message payload",
+                         message_contents["publish1"],
+                         msg="Expect publish1 to be expected byte[]")
+        self.assertEqual({"test": "This is a JSONObject message payload"},
+                         json.loads(message_contents["publish2"]),
+                         msg="Expect publish2 to be expected JSONObject")
+        self.assertEqual(["This is a JSONArray message payload"],
+                         json.loads(message_contents["publish3"]),
+                         msg="Expect publish3 to be expected JSONObject")
 
     def test_publish_message_list(self):
         channel = TestRestChannelPublish.ably.channels["message_list_channel"]

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -9,15 +9,18 @@ import time
 import unittest
 
 import six
+from six.moves import range
 
 from ably import AblyException
 from ably import AblyRest
 from ably import Options
+from ably.types.message import Message
 
 from test.ably.restsetup import RestSetup
 
 test_vars = RestSetup.get_test_vars()
 log = logging.getLogger(__name__)
+
 
 class TestRestChannelPublish(unittest.TestCase):
     @classmethod
@@ -39,76 +42,76 @@ class TestRestChannelPublish(unittest.TestCase):
     def test_publish_various_datatypes_text(self):
         publish0 = TestRestChannelPublish.ably.channels["persisted:publish0"]
 
-        publish0.publish("publish0", True)
-        publish0.publish("publish1", 24)
-        publish0.publish("publish2", 24.234)
-        publish0.publish("publish3", six.u("This is a string message payload"))
-        publish0.publish("publish4", b"This is a byte[] message payload")
-        publish0.publish("publish5", {"test": "This is a JSONObject message payload"})
-        publish0.publish("publish6", ["This is a JSONArray message payload"])
+        publish0.publish("publish0", six.u("This is a string message payload"))
+        publish0.publish("publish1", b"This is a byte[] message payload")
+        publish0.publish("publish2", {"test": "This is a JSONObject message payload"})
+        publish0.publish("publish3", ["This is a JSONArray message payload"])
 
         # Get the history for this channel
         history = publish0.history()
         messages = history.current
         self.assertIsNotNone(messages, msg="Expected non-None messages")
-        self.assertEqual(7, len(messages), msg="Expected 7 messages")
-        
+        self.assertEqual(4, len(messages), msg="Expected 4 messages")
+
         message_contents = dict((m.name, m.data) for m in messages)
         log.debug("message_contents: %s" % str(message_contents))
 
-        self.assertEqual(True, message_contents["publish0"],
-                msg="Expect publish0 to be Boolean(true)")
-        self.assertEqual(24, int(message_contents["publish1"]),
-                msg="Expect publish1 to be Int(24)")
-        self.assertEqual(24.234, float(message_contents["publish2"]),
-                msg="Expect publish2 to be Double(24.234)")
         self.assertEqual(six.u("This is a string message payload"),
-                message_contents["publish3"],
-                msg="Expect publish3 to be expected String)")
+                         message_contents["publish0"],
+                         msg="Expect publish0 to be expected String)")
         self.assertEqual(b"This is a byte[] message payload",
-                message_contents["publish4"],
-                msg="Expect publish4 to be expected byte[]. Actual: %s" % str(message_contents['publish4']))
+                         message_contents["publish1"],
+                         msg="Expect publish1 to be expected byte[]. Actual: %s" %
+                             str(message_contents['publish1']))
         self.assertEqual({"test": "This is a JSONObject message payload"},
-                message_contents["publish5"],
-                msg="Expect publish5 to be expected JSONObject")
+                         message_contents["publish2"],
+                         msg="Expect publish2 to be expected JSONObject")
         self.assertEqual(["This is a JSONArray message payload"],
-                message_contents["publish6"],
-                msg="Expect publish6 to be expected JSONObject")
+                         message_contents["publish3"],
+                         msg="Expect publish3 to be expected JSONObject")
 
-    def test_publish_various_datatypes_binary(self):
-        publish1 = TestRestChannelPublish.ably_binary.channels.publish1
+    # TODO: test messagepack later
+    # def test_publish_various_datatypes_binary(self):
+    #     publish1 = TestRestChannelPublish.ably_binary.channels.publish1
 
-        publish1.publish("publish0", True)
-        publish1.publish("publish1", 24)
-        publish1.publish("publish2", 24.234)
-        publish1.publish("publish3", "This is a string message payload")
-        publish1.publish("publish4", bytearray("This is a byte[] message payload", "utf_8"))
-        publish1.publish("publish5", {"test": "This is a JSONObject message payload"})
-        publish1.publish("publish6", ["This is a JSONArray message payload"])
+    #     publish1.publish("publish0", "This is a string message payload")
+    #     publish1.publish("publish1", bytearray("This is a byte[] message payload", "utf_8"))
+    #     publish1.publish("publish2", {"test": "This is a JSONObject message payload"})
+    #     publish1.publish("publish3", ["This is a JSONArray message payload"])
+
+    #     # Get the history for this channel
+    #     messages = publish1.history()
+    #     self.assertIsNotNone(messages, msg="Expected non-None messages")
+    #     self.assertEqual(4, len(messages), msg="Expected 4 messages")
+
+    #     message_contents = dict((m.name, m.data) for m in messages)
+
+    #     self.assertEqual("This is a string message payload",
+    #                      message_contents["publish0"],
+    #                      msg="Expect publish0 to be expected String)")
+    #     self.assertEqual("This is a byte[] message payload",
+    #                      message_contents["publish1"],
+    #                      msg="Expect publish1 to be expected byte[]")
+    #     self.assertEqual({"test": "This is a JSONObject message payload"},
+    #                      json.loads(message_contents["publish2"]),
+    #                      msg="Expect publish2 to be expected JSONObject")
+    #     self.assertEqual(["This is a JSONArray message payload"],
+    #                      json.loads(message_contents["publish3"]),
+    #                      msg="Expect publish3 to be expected JSONObject")
+
+    def test_publish_message_list(self):
+        channel = TestRestChannelPublish.ably.channels["message_list_channel"]
+        expected_messages = [Message("name-{}".format(i), str(i)) for i in range(3)]
+
+        channel.publish(messages=expected_messages)
 
         # Get the history for this channel
-        messages = publish1.history()
+        history = channel.history()
+        messages = history.current
         self.assertIsNotNone(messages, msg="Expected non-None messages")
-        self.assertEqual(7, len(messages), msg="Expected 7 messages")
+        self.assertEqual(len(messages), len(expected_messages), msg="Expected 3 messages")
 
-        message_contents = dict((m.name, m.data) for m in messages)
-
-        self.assertEqual(True, message_contents["publish0"],
-               msg="Expect publish0 to be Boolean(true)")
-        self.assertEqual(24, int(message_contents["publish1"]),
-               msg="Expect publish1 to be Int(24)")
-        self.assertEqual(24.234, float(message_contents["publish2"]),
-               msg="Expect publish2 to be Double(24.234)")
-        self.assertEqual("This is a string message payload",
-               message_contents["publish3"],
-               msg="Expect publish3 to be expected String)")
-        self.assertEqual("This is a byte[] message payload",
-               message_contents["publish4"],
-               msg="Expect publish4 to be expected byte[]")
-        self.assertEqual({"test": "This is a JSONObject message payload"},
-               json.loads(message_contents["publish5"]),
-               msg="Expect publish5 to be expected JSONObject")
-        self.assertEqual(["This is a JSONArray message payload"],
-               json.loads(message_contents["publish6"]),
-               msg="Expect publish6 to be expected JSONObject")
-
+        for m, expected_m in zip(sorted(messages,          key=lambda m: m.name),
+                                 sorted(expected_messages, key=lambda m: m.name)):
+            self.assertEqual(m.name, expected_m.name)
+            self.assertEqual(m.data, expected_m.data)

--- a/test/ably/restcrypto_test.py
+++ b/test/ably/restcrypto_test.py
@@ -19,6 +19,8 @@ from test.ably.restsetup import RestSetup
 test_vars = RestSetup.get_test_vars()
 log = logging.getLogger(__name__)
 
+
+@unittest.skip("crypto not implemented")
 class TestRestCrypto(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tox.ini
+++ b/tox.ini
@@ -11,5 +11,5 @@ deps =
     -rrequirements.txt
 
 commands=
-    nosetests --with-coverage --cover-package=ably -I restappstats_test -I restcrypto_test -v
+    nosetests --with-coverage --cover-package=ably -v
     coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -11,5 +11,5 @@ deps =
     -rrequirements.txt
 
 commands=
-    nosetests --with-coverage --cover-package=ably -I restappstats_test -I restchannelpublish_test -I restcrypto_test -v
+    nosetests --with-coverage --cover-package=ably -I restappstats_test -I restcrypto_test -v
     coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -6,13 +6,10 @@ envlist =
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 
 deps =
-   msgpack-python>=0.4.6
-   pycrypto>=2.6.1
-   requests>=2.7.0,<2.8
-   six>=1.9.0
-   nose>=1.0.0
-   mock>=1.3.0
-   coveralls>=0.5
+    -rrequirements.txt
+    nose>=1.0.0
+    mock>=1.3.0
+    coveralls>=0.5
 
 commands =
     python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,15 @@ envlist =
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 
 deps =
-    nose
-    coveralls
-    -rrequirements.txt
+   msgpack-python>=0.4.6
+   pycrypto>=2.6.1
+   requests>=2.7.0,<2.8
+   six>=1.9.0
+   nose>=1.0.0
+   mock>=1.3.0
+   coveralls>=0.5
 
-commands=
-    nosetests --with-coverage --cover-package=ably -v
+commands =
+    python setup.py test
+    nosetests {posargs:--with-coverage --cover-package=ably -v}
     coveralls


### PR DESCRIPTION
(RSL1a) Expects either an array of Message objects or a name string and data payload.
(RSL1b) When name and data is provided, a single message is published to Ably
(RSL1c) When an array of Message objects is provided, a single request is made to Ably. When publishing multiple messages, this approach is more efficient. However, a yet to be implemented feature should limit the total number of messages bundled in a single POST based on the default max request size, and would raise an exception if any single message exceeds that limit. **(missing check limit)**
(RSL1e) Allows name and or data to be null. If any of the values are null, then key is not sent to Ably i.e. a payload with a null value for data would be sent as follows { "name": "click" }		