### PR TITLE
(RSL1d) Indicates an error if the message was not successfully published to Ably

### DIFF
--- a/ably/rest/auth.py
+++ b/ably/rest/auth.py
@@ -34,7 +34,6 @@ class Auth(object):
         self.__auth_options = options
 
         self.__basic_credentials = None
-        self.__token_credentials = None
         self.__auth_params = None
         self.__token_details = None
 
@@ -70,6 +69,8 @@ class Auth(object):
             log.debug("no authentication parameters supplied")
 
     def authorise(self, force=False, **kwargs):
+        self.__auth_method = Auth.Method.TOKEN
+
         if self.__token_details:
             if self.__token_details.expires > self._timestamp():
                 if not force:
@@ -250,8 +251,8 @@ class Auth(object):
         return self.__basic_credentials
 
     @property
-    def token_credentials(self):
-        return self.__token_credentials
+    def token_details(self):
+        return self.__token_details
 
     def _get_auth_headers(self):
         if self.__auth_method == Auth.Method.BASIC:

--- a/ably/rest/auth.py
+++ b/ably/rest/auth.py
@@ -251,17 +251,25 @@ class Auth(object):
         return self.__basic_credentials
 
     @property
+    def token_credentials(self):
+        if self.__token_details:
+            token = self.__token_details.token
+            token_key = base64.b64encode(token.encode('utf-8'))
+            return token_key.decode('ascii')
+
+    @property
     def token_details(self):
         return self.__token_details
 
     def _get_auth_headers(self):
         if self.__auth_method == Auth.Method.BASIC:
             return {
-                'Authorization': 'Basic %s' % self.__basic_credentials,
+                'Authorization': 'Basic %s' % self.basic_credentials,
             }
         else:
+            self.authorise()
             return {
-                'Authorization': 'Bearer %s' % self.authorise().token,
+                'Authorization': 'Bearer %s' % self.token_credentials,
             }
 
     def _timestamp(self):

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -135,8 +135,8 @@ class TestRestChannelPublish(unittest.TestCase):
         with self.assertRaises(AblyException) as cm:
             ably.channels["only_subscribe"].publish()
 
-        self.assertEqual(400, cm.exception.status_code)
-        self.assertEqual(40000, cm.exception.code)
+        self.assertEqual(401, cm.exception.status_code)
+        self.assertEqual(40160, cm.exception.code)
 
     def test_publish_message_null_name(self):
         channel = TestRestChannelPublish.ably.channels["message_null_name_channel"]

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -117,6 +117,27 @@ class TestRestChannelPublish(unittest.TestCase):
             self.assertEqual(m.name, expected_m.name)
             self.assertEqual(m.data, expected_m.data)
 
+    def test_publish_error(self):
+        token_params = {
+            "capability": {
+                "only_subscribe": ["subscribe"],
+            }
+        }
+
+        ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                        host=test_vars["host"],
+                        port=test_vars["port"],
+                        tls_port=test_vars["tls_port"],
+                        tls=test_vars["tls"],
+                        use_text_protocol=True)
+        ably.auth.authorise(token_params=token_params)
+
+        with self.assertRaises(AblyException) as cm:
+            ably.channels["only_subscribe"].publish()
+
+        self.assertEqual(400, cm.exception.status_code)
+        self.assertEqual(40000, cm.exception.code)
+
     def test_publish_message_null_name(self):
         channel = TestRestChannelPublish.ably.channels["message_null_name_channel"]
 


### PR DESCRIPTION
Based on: https://github.com/ably/ably-ruby/blob/382340047898e774cc71516eb30e9b9493a55cba/spec/acceptance/rest/channel_spec.rb#L57-L64