### PR TITLE
RSL2a and RSL2b3 - Channel#history

### DIFF
--- a/ably/rest/channel.py
+++ b/ably/rest/channel.py
@@ -42,6 +42,8 @@ class Channel(object):
         if direction:
             params['direction'] = '%s' % direction
         if limit:
+            if limit > 1000:
+                raise ValueError("The maximum allowed limit is 1000")
             params['limit'] = '%d' % limit
         if start:
             params['start'] = self._format_time_param(start)

--- a/test/ably/restchannelhistory_test.py
+++ b/test/ably/restchannelhistory_test.py
@@ -13,6 +13,7 @@ from six.moves import range
 from ably import AblyException
 from ably import AblyRest
 from ably import Options
+from ably.http.paginatedresult import PaginatedResult
 
 from test.ably.restsetup import RestSetup
 
@@ -42,6 +43,7 @@ class TestRestChannelHistory(unittest.TestCase):
         history0.publish('history3', ['This is a JSONArray message payload'])
 
         history = history0.history()
+        self.assertIsInstance(history, PaginatedResult)
         messages = history.items
         self.assertIsNotNone(messages, msg="Expected non-None messages")
         self.assertEqual(4, len(messages), msg="Expected 4 messages")

--- a/test/ably/restchannelhistory_test.py
+++ b/test/ably/restchannelhistory_test.py
@@ -7,6 +7,7 @@ import logging
 import time
 import unittest
 
+import responses
 import six
 from six.moves import range
 
@@ -106,6 +107,43 @@ class TestRestChannelHistory(unittest.TestCase):
 
         self.assertEqual(expected_messages, messages,
                 msg='Expect messages in reverse order')
+
+    def history_mock_url(self, channel_name):
+        kwargs = {
+            'scheme': 'https' if test_vars['tls'] else 'http',
+            'host': test_vars['host'],
+            'channel_name': channel_name
+        }
+        port = test_vars['tls_port'] if test_vars.get('tls') else kwargs['port']
+        if port == 80:
+            kwargs['port_sufix'] = ''
+        else:
+            kwargs['port_sufix'] = ':' + str(port)
+        url = '{scheme}://{host}{port_sufix}/channels/{channel_name}/history'
+        return url.format(**kwargs)
+
+    @responses.activate
+    def test_channel_history_default_limit(self):
+        channel = TestRestChannelHistory.ably.channels['persisted:channelhistory_limit']
+        url = self.history_mock_url('persisted:channelhistory_limit')
+        responses.add(responses.GET, url, body='{}')
+        channel.history()
+        self.assertNotIn('limit=', responses.calls[0].request.url.split('?')[-1])
+
+    @responses.activate
+    def test_channel_history_with_limits(self):
+        channel = TestRestChannelHistory.ably.channels['persisted:channelhistory_limit']
+        url = self.history_mock_url('persisted:channelhistory_limit')
+        responses.add(responses.GET, url, body='{}')
+        channel.history(limit=500)
+        self.assertIn('limit=500', responses.calls[0].request.url.split('?')[-1])
+        channel.history(limit=1000)
+        self.assertIn('limit=1000', responses.calls[1].request.url.split('?')[-1])
+
+    def test_channel_history_max_limit_is_1000(self):
+        channel = TestRestChannelHistory.ably.channels['persisted:channelhistory_limit']
+        with self.assertRaises(AblyException):
+            channel.history(limit=1001)
 
     def test_channel_history_limit_forwards(self):
         history0 = TestRestChannelHistory.ably.channels['persisted:channelhistory_limit_f']


### PR DESCRIPTION
* Channel#history function:			
    * (RSL2a) Returns a PaginatedResult page containing the first page of messages in thePaginatedResult#items attribute returned from the history request
    * Supports the following params:	
          * (RSL2b3) limit supports up to 1,000 items; if omitted the direction defaults to the REST API default (100)	