### PR TITLE
Add Query time parameter TO3j10 and RSA9d

### DIFF
--- a/ably/rest/auth.py
+++ b/ably/rest/auth.py
@@ -25,6 +25,7 @@ log = logging.getLogger(__name__)
 
 
 class Auth(object):
+
     class Method:
         BASIC = "BASIC"
         TOKEN = "TOKEN"
@@ -94,6 +95,8 @@ class Auth(object):
 
         log.debug("Auth callback: %s" % auth_callback)
         log.debug("Auth options: %s" % six.text_type(self.auth_options))
+        if query_time is None:
+            query_time = self.auth_options.query_time
         query_time = bool(query_time)
         auth_token = auth_token or self.auth_options.auth_token
         auth_callback = auth_callback or self.auth_options.auth_callback
@@ -154,7 +157,7 @@ class Auth(object):
         return TokenDetails.from_dict(response_json)
 
     def create_token_request(self, key_name=None, key_secret=None,
-                             query_time=False, token_params=None):
+                             query_time=None, token_params=None):
         token_params = token_params or {}
 
         if token_params.setdefault("id", key_name) != key_name:
@@ -163,6 +166,9 @@ class Auth(object):
         if not key_name or not key_secret:
             log.debug('key_name or key_secret blank')
             raise AblyException("No key specified", 401, 40101)
+
+        if query_time is None:
+            query_time = self.auth_options.query_time
 
         if not token_params.get("timestamp"):
             if query_time:

--- a/test/ably/restinit_test.py
+++ b/test/ably/restinit_test.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 import unittest
 
+from mock import patch
+
 from ably import AblyRest
 from ably import AblyException
 from ably.transport.defaults import Defaults
@@ -84,6 +86,19 @@ class TestRestInit(unittest.TestCase):
     def test_with_no_auth_params(self):
         self.assertRaises(ValueError, AblyRest, port=111)
 
+    def test_query_time_param(self):
+        ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                        host=test_vars["host"],
+                        port=test_vars["port"],
+                        tls_port=test_vars["tls_port"],
+                        tls=test_vars["tls"], query_time=True)
+
+        timestamp = ably.auth._timestamp
+        with patch('ably.rest.rest.AblyRest.time', wraps=ably.time) as server_time,\
+                patch('ably.rest.auth.Auth._timestamp', wraps=timestamp) as local_time:
+            ably.auth.request_token()
+            self.assertFalse(local_time.called)
+            self.assertTrue(server_time.called)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
* The attributes of ClientOptions consist of:
  * Auth option attributes:
    * (TO3j10) queryTime – If true, the library will query the Ably system for the current time instead of relying on a locally-available time of day
* Auth#createTokenRequest function:
  * (RSA9d) Generates a timestamp from current time if not provided, will retrieve the server time if queryTime is true