### PR TITLE
Message pack

### DIFF
--- a/ably/http/http.py
+++ b/ably/http/http.py
@@ -90,8 +90,7 @@ class Http(object):
             fallback_hosts.insert(0, self.preferred_host)
             fallback_hosts = itertools.cycle(fallback_hosts)
 
-        all_headers = HttpUtils.default_get_headers(not self.options.use_text_protocol)
-        all_headers.update(headers or {})
+        all_headers = headers or {}
         if not skip_auth:
             all_headers.update(self.auth._get_auth_headers())
 

--- a/ably/http/httputils.py
+++ b/ably/http/httputils.py
@@ -16,9 +16,9 @@ class HttpUtils(object):
     @staticmethod
     def default_get_headers(binary=False):
         if binary:
-            raise AblyException(message="Binary protocol is not implemented",
-                                status_code=400,
-                                code=40000)
+            return {
+                "Accept": "application/x-msgpack"
+            }
         else:
             return {
                 "Accept": "application/json",
@@ -27,9 +27,10 @@ class HttpUtils(object):
     @staticmethod
     def default_post_headers(binary=False):
         if binary:
-            raise AblyException(message="Binary protocol is not implemented",
-                                status_code=400,
-                                code=40000)
+            return {
+                "Accept": "application/x-msgpack" ,
+                "Content-Type": "application/x-msgpack"
+            }
         else:
             return {
                 "Accept": "application/json",

--- a/ably/http/httputils.py
+++ b/ably/http/httputils.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from ably.util.exceptions import AblyException
-
 
 class HttpUtils(object):
     default_format = "json"
@@ -28,7 +26,7 @@ class HttpUtils(object):
     def default_post_headers(binary=False):
         if binary:
             return {
-                "Accept": "application/x-msgpack" ,
+                "Accept": "application/x-msgpack",
                 "Content-Type": "application/x-msgpack"
             }
         else:

--- a/ably/http/paginatedresult.py
+++ b/ably/http/paginatedresult.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import logging
 
 from ably.http.http import Request
+from ably.http.httputils import HttpUtils
 
 log = logging.getLogger(__name__)
 
@@ -43,7 +44,10 @@ class PaginatedResult(object):
 
     @staticmethod
     def paginated_query(http, url, headers, response_processor):
-        req = Request(method='GET', url=url, headers=headers, body=None, skip_auth=True)
+        headers = headers or {}
+        all_headers = HttpUtils.default_get_headers(http.options.use_binary_protocol)
+        all_headers.update(headers)
+        req = Request(method='GET', url=url, headers=all_headers, body=None, skip_auth=True)
         return PaginatedResult.paginated_query_with_request(http, req, response_processor)
 
     @staticmethod

--- a/ably/rest/channel.py
+++ b/ably/rest/channel.py
@@ -58,10 +58,10 @@ class Channel(object):
 
         if self.__cipher:
             message_handler = make_encrypted_message_response_handler(
-                self.__cipher, not self.ably.options.use_text_protocol)
+                self.__cipher, self.ably.options.use_binary_protocol)
         else:
             message_handler = make_message_response_handler(
-                not self.ably.options.use_text_protocol)
+                self.ably.options.use_binary_protocol)
 
         return PaginatedResult.paginated_query(
             self.ably.http,
@@ -92,7 +92,7 @@ class Channel(object):
 
             request_body_list.append(m)
 
-        if self.ably.options.use_text_protocol:
+        if not self.ably.options.use_binary_protocol:
             if len(request_body_list) == 1:
                 request_body = request_body_list[0].as_json()
             else:
@@ -106,7 +106,7 @@ class Channel(object):
                     use_bin_type=True)
 
         path = '/channels/%s/publish' % self.__name
-        headers = HttpUtils.default_post_headers(not self.ably.options.use_text_protocol)
+        headers = HttpUtils.default_post_headers(self.ably.options.use_binary_protocol)
 
         return self.ably.http.post(
             path,

--- a/ably/rest/channel.py
+++ b/ably/rest/channel.py
@@ -6,12 +6,13 @@ import json
 from collections import OrderedDict
 
 import six
+import msgpack
 from six.moves.urllib.parse import urlencode, quote
 
 from ably.http.httputils import HttpUtils
 from ably.http.paginatedresult import PaginatedResult
 from ably.types.message import (
-    Message, message_response_handler, make_encrypted_message_response_handler,
+    Message, make_message_response_handler, make_encrypted_message_response_handler,
     MessageJSONEncoder)
 from ably.types.presence import Presence
 from ably.util.crypto import get_cipher
@@ -56,9 +57,11 @@ class Channel(object):
             path = path + '?' + urlencode(params)
 
         if self.__cipher:
-            message_handler = make_encrypted_message_response_handler(self.__cipher)
+            message_handler = make_encrypted_message_response_handler(
+                self.__cipher, not self.ably.options.use_text_protocol)
         else:
-            message_handler = message_response_handler
+            message_handler = make_message_response_handler(
+                not self.ably.options.use_text_protocol)
 
         return PaginatedResult.paginated_query(
             self.ably.http,
@@ -82,10 +85,6 @@ class Channel(object):
         if not messages:
             messages = [Message(name, data)]
 
-        # TODO: messagepack
-        if not self.ably.options.use_text_protocol:
-            raise NotImplementedError
-
         request_body_list = []
         for m in messages:
             if self.encrypted:
@@ -93,19 +92,28 @@ class Channel(object):
 
             request_body_list.append(m)
 
-        if len(request_body_list) == 1:
-            request_body = request_body_list[0].as_json()
+        if self.ably.options.use_text_protocol:
+            if len(request_body_list) == 1:
+                request_body = request_body_list[0].as_json()
+            else:
+                request_body = json.dumps(request_body_list, cls=MessageJSONEncoder)
         else:
-            request_body = json.dumps(request_body_list, cls=MessageJSONEncoder)
+            if len(request_body_list) == 1:
+                request_body = request_body_list[0].as_msgpack()
+            else:
+                request_body = msgpack.packb(
+                    [message.as_dict(binary=True) for message in request_body_list],
+                    use_bin_type=True)
 
         path = '/channels/%s/publish' % self.__name
         headers = HttpUtils.default_post_headers(not self.ably.options.use_text_protocol)
+
         return self.ably.http.post(
             path,
             headers=headers,
             body=request_body,
             timeout=timeout
-        ).json()
+            )
 
     @property
     def ably(self):

--- a/ably/types/message.py
+++ b/ably/types/message.py
@@ -108,26 +108,31 @@ class Message(EncodeDataMixin):
         if decrypted_data is not None:
             self.__data = decrypted_data
 
-    def as_dict(self):
+    def as_dict(self, binary=False):
         data = self.data
         data_type = None
         encoding = self._encoding_array[:]
+
         if isinstance(data, dict) or isinstance(data, list):
             encoding.append('json')
             data = json.dumps(data)
 
-        elif isinstance(self.data, six.binary_type):
+        elif isinstance(self.data, six.binary_type) and not binary:
             data = base64.b64encode(data).decode('ascii')
             encoding.append('base64')
-
-        elif isinstance(data, six.text_type):
+        elif isinstance(data, six.text_type) and not binary:
             encoding.append('utf-8')
-
+        elif isinstance(data, (six.text_type, six.binary_type)):
+            # only if is binary
+            pass
         elif isinstance(data, CipherData):
             encoding.append(data.encoding_str)
             data_type = data.type
-            data = base64.b64encode(data.buffer).decode('ascii')
-            encoding.append('base64')
+            if not binary:
+                data = base64.b64encode(data.buffer).decode('ascii')
+                encoding.append('base64')
+            else:
+                data = data.buffer
 
         if not (isinstance(data, (six.binary_type, six.text_type, list, dict)) or
                 data is None):
@@ -162,7 +167,7 @@ class Message(EncodeDataMixin):
         return json.dumps(self.as_dict(), separators=(',', ':'))
 
     @staticmethod
-    def from_json(obj, cipher=None):
+    def from_dict(obj, cipher=None):
         id = obj.get('id')
         name = obj.get('name')
         data = obj.get('data')
@@ -183,64 +188,26 @@ class Message(EncodeDataMixin):
         )
 
     def as_msgpack(self):
-        data = self.data
-        encoding = None
-        data_type = None
-
-        # log.debug(data.__class__)
-
-        if isinstance(data, CipherData):
-            data_type = data.type
-            data = base64.b64encode(data.buffer).decode('ascii')
-            encoding = 'cipher+base64'
-        if isinstance(data, six.binary_type):
-            data = base64.b64encode(data).decode('ascii')
-            encoding = 'base64'
-
-        # log.debug(data)
-        # log.debug(data.__class__)
-
-        request_body = {
-            'name': self.name,
-            'data': data,
-            'timestamp': self.timestamp or int(time.time() * 1000.0),
-        }
-
-        if encoding:
-            request_body['encoding'] = encoding
-
-        if data_type:
-            request_body['type'] = data_type
-
-        request_body = json.dumps(request_body)
-        return request_body
-
-    @staticmethod
-    def from_msgpack(obj):
-        name = obj.get('name')
-        data = obj.get('data')
-        timestamp = obj.get('timestamp')
-        encoding = obj.get('encoding')
-
-        # log.debug("MESSAGE: %s", str(obj))
-
-        if encoding and encoding == six.u('base64'):
-            data = msgpack.loads(base64.b64decode(data))
-        elif encoding and encoding == six.u('cipher+base64'):
-            ciphertext = base64.b64decode(data)
-            data = CipherData(ciphertext, obj.get('type'))
-            data = msgpack.loads(data)
-
-        return Message(name=name, data=data, timestamp=timestamp)
+        return msgpack.packb(self.as_dict(binary=True), use_bin_type=True)
 
 
-def message_response_handler(response):
-    return [Message.from_json(j) for j in response.json()]
+def make_message_response_handler(binary):
+    def message_response_handler(response):
+        if binary:
+            messages = msgpack.unpackb(response.content, encoding='utf-8')
+        else:
+            messages = response.json()
+        return [Message.from_dict(j) for j in messages]
+    return message_response_handler
 
 
-def make_encrypted_message_response_handler(cipher):
+def make_encrypted_message_response_handler(cipher, binary):
     def encrypted_message_response_handler(response):
-        return [Message.from_json(j, cipher) for j in response.json()]
+        if binary:
+            messages = msgpack.unpackb(response.content, encoding='utf-8')
+        else:
+            messages = response.json()
+        return [Message.from_dict(j, cipher) for j in messages]
     return encrypted_message_response_handler
 
 

--- a/ably/types/options.py
+++ b/ably/types/options.py
@@ -6,7 +6,7 @@ from ably.util.exceptions import AblyException
 
 class Options(AuthOptions):
     def __init__(self, client_id=None, log_level=0, tls=True, host=None,
-                 ws_host=None, port=0, tls_port=0, use_text_protocol=True,
+                 ws_host=None, port=0, tls_port=0, use_binary_protocol=True,
                  queue_messages=False, recover=False, **kwargs):
         super(Options, self).__init__(**kwargs)
 
@@ -19,7 +19,7 @@ class Options(AuthOptions):
         self.__ws_host = ws_host
         self.__port = port
         self.__tls_port = tls_port
-        self.__use_text_protocol = use_text_protocol
+        self.__use_binary_protocol = use_binary_protocol
         self.__queue_messages = queue_messages
         self.__recover = recover
 
@@ -72,12 +72,12 @@ class Options(AuthOptions):
         self.__tls_port = value
 
     @property
-    def use_text_protocol(self):
-        return self.__use_text_protocol
+    def use_binary_protocol(self):
+        return self.__use_binary_protocol
 
-    @use_text_protocol.setter
-    def use_text_protocol(self, value):
-        self.__use_text_protocol = value
+    @use_binary_protocol.setter
+    def use_binary_protocol(self, value):
+        self.__use_binary_protocol = value
 
     @property
     def queue_messages(self):

--- a/ably/types/presence.py
+++ b/ably/types/presence.py
@@ -108,7 +108,7 @@ class PresenceMessage(EncodeDataMixin):
 class Presence(object):
     def __init__(self, channel):
         self.__base_path = channel.base_path
-        self.__binary = not channel.ably.options.use_text_protocol
+        self.__binary = channel.ably.options.use_binary_protocol
         self.__http = channel.ably.http
         self.__cipher = channel.cipher
 

--- a/ably/util/crypto.py
+++ b/ably/util/crypto.py
@@ -43,10 +43,6 @@ class CipherParams(object):
     def mode(self):
         return self.__mode
 
-    @property
-    def key_length(self):
-        return self.__key_length
-
 
 class CbcChannelCipher(object):
     def __init__(self, cipher_params):

--- a/test/ably/encoders_test.py
+++ b/test/ably/encoders_test.py
@@ -7,6 +7,7 @@ import unittest
 
 import six
 import mock
+import msgpack
 
 from ably import AblyRest
 from ably import ChannelOptions, CipherParams
@@ -19,7 +20,7 @@ test_vars = RestSetup.get_test_vars()
 log = logging.getLogger(__name__)
 
 
-class TestEncodersNoEncryption(unittest.TestCase):
+class TestTextEncodersNoEncryption(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
@@ -32,19 +33,17 @@ class TestEncodersNoEncryption(unittest.TestCase):
     def test_text_utf8(self):
         channel = self.ably.channels["persisted:publish"]
 
-        with mock.patch('ably.rest.rest.Http.post',
-                        wraps=channel.ably.http.post) as post_mock:
+        with mock.patch('ably.rest.rest.Http.post') as post_mock:
             channel.publish('event', six.u('foó'))
             _, kwargs = post_mock.call_args
             self.assertEqual(json.loads(kwargs['body'])['data'], six.u('foó'))
-            self.assertEqual(json.loads(kwargs['body']).get('encoding').strip('/'),
+            self.assertEqual(json.loads(kwargs['body']).get('encoding', '').strip('/'),
                              'utf-8')
 
     def test_with_binary_type(self):
         channel = self.ably.channels["persisted:publish"]
 
-        with mock.patch('ably.rest.rest.Http.post',
-                        wraps=channel.ably.http.post) as post_mock:
+        with mock.patch('ably.rest.rest.Http.post') as post_mock:
             channel.publish('event', six.b('foo'))
             _, kwargs = post_mock.call_args
             raw_data = json.loads(kwargs['body'])['data']
@@ -56,8 +55,7 @@ class TestEncodersNoEncryption(unittest.TestCase):
     def test_with_json_dict_data(self):
         channel = self.ably.channels["persisted:publish"]
         data = {six.u('foó'): six.u('bár')}
-        with mock.patch('ably.rest.rest.Http.post',
-                        wraps=channel.ably.http.post) as post_mock:
+        with mock.patch('ably.rest.rest.Http.post') as post_mock:
             channel.publish('event', data)
             _, kwargs = post_mock.call_args
             raw_data = json.loads(json.loads(kwargs['body'])['data'])
@@ -68,8 +66,7 @@ class TestEncodersNoEncryption(unittest.TestCase):
     def test_with_json_list_data(self):
         channel = self.ably.channels["persisted:publish"]
         data = [six.u('foó'), six.u('bár')]
-        with mock.patch('ably.rest.rest.Http.post',
-                        wraps=channel.ably.http.post) as post_mock:
+        with mock.patch('ably.rest.rest.Http.post') as post_mock:
             channel.publish('event', data)
             _, kwargs = post_mock.call_args
             raw_data = json.loads(json.loads(kwargs['body'])['data'])
@@ -119,7 +116,7 @@ class TestEncodersNoEncryption(unittest.TestCase):
         self.assertEqual(decoded_data['encoding'], 'foo/bar')
 
 
-class TestEncodersEncryption(unittest.TestCase):
+class TestTextEncodersEncryption(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
@@ -141,8 +138,7 @@ class TestEncodersEncryption(unittest.TestCase):
                                          options=ChannelOptions(
                                             encrypted=True,
                                             cipher_params=self.cipher_params))
-        with mock.patch('ably.rest.rest.Http.post',
-                        wraps=channel.ably.http.post) as post_mock:
+        with mock.patch('ably.rest.rest.Http.post') as post_mock:
             channel.publish('event', six.u('fóo'))
             _, kwargs = post_mock.call_args
             self.assertEquals(json.loads(kwargs['body'])['encoding'].strip('/'),
@@ -156,8 +152,7 @@ class TestEncodersEncryption(unittest.TestCase):
                                             encrypted=True,
                                             cipher_params=self.cipher_params))
 
-        with mock.patch('ably.rest.rest.Http.post',
-                        wraps=channel.ably.http.post) as post_mock:
+        with mock.patch('ably.rest.rest.Http.post') as post_mock:
             channel.publish('event', six.b('foo'))
             _, kwargs = post_mock.call_args
 
@@ -173,8 +168,7 @@ class TestEncodersEncryption(unittest.TestCase):
                                             encrypted=True,
                                             cipher_params=self.cipher_params))
         data = {six.u('foó'): six.u('bár')}
-        with mock.patch('ably.rest.rest.Http.post',
-                        wraps=channel.ably.http.post) as post_mock:
+        with mock.patch('ably.rest.rest.Http.post') as post_mock:
             channel.publish('event', data)
             _, kwargs = post_mock.call_args
             self.assertEquals(json.loads(kwargs['body'])['encoding'].strip('/'),
@@ -188,8 +182,7 @@ class TestEncodersEncryption(unittest.TestCase):
                                             encrypted=True,
                                             cipher_params=self.cipher_params))
         data = [six.u('foó'), six.u('bár')]
-        with mock.patch('ably.rest.rest.Http.post',
-                        wraps=channel.ably.http.post) as post_mock:
+        with mock.patch('ably.rest.rest.Http.post') as post_mock:
             channel.publish('event', data)
             _, kwargs = post_mock.call_args
             self.assertEquals(json.loads(kwargs['body'])['encoding'].strip('/'),
@@ -233,6 +226,224 @@ class TestEncodersEncryption(unittest.TestCase):
 
     def test_with_json_list_data_decode(self):
         channel = self.ably.channels.get("persisted:enc_list",
+                                         options=ChannelOptions(
+                                            encrypted=True,
+                                            cipher_params=self.cipher_params))
+        data = [six.u('foó'), six.u('bár')]
+        channel.publish('event', data)
+        message = channel.history().items[0]
+        self.assertEqual(message.data, data)
+        self.assertFalse(message.encoding)
+
+
+class TestBinaryEncodersNoEncryption(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                            host=test_vars["host"],
+                            port=test_vars["port"],
+                            tls_port=test_vars["tls_port"],
+                            tls=test_vars["tls"],
+                            use_text_protocol=False)
+
+    def decode(self, data):
+        return msgpack.unpackb(data, encoding='utf-8')
+
+    def test_text_utf8(self):
+        channel = self.ably.channels["persisted:publish"]
+
+        with mock.patch('ably.rest.rest.Http.post',
+                        wraps=channel.ably.http.post) as post_mock:
+            channel.publish('event', six.u('foó'))
+            _, kwargs = post_mock.call_args
+            self.assertEqual(self.decode(kwargs['body'])['data'], six.u('foó'))
+            self.assertEqual(self.decode(kwargs['body']).get('encoding', '').strip('/'), '')
+
+    def test_with_binary_type(self):
+        channel = self.ably.channels["persisted:publish"]
+
+        with mock.patch('ably.rest.rest.Http.post',
+                        wraps=channel.ably.http.post) as post_mock:
+            channel.publish('event', six.b('foo'))
+            _, kwargs = post_mock.call_args
+            self.assertEqual(self.decode(kwargs['body'])['data'], six.b('foo'))
+            self.assertEqual(self.decode(kwargs['body']).get('encoding', '').strip('/'), '')
+
+    def test_with_json_dict_data(self):
+        channel = self.ably.channels["persisted:publish"]
+        data = {six.u('foó'): six.u('bár')}
+        with mock.patch('ably.rest.rest.Http.post',
+                        wraps=channel.ably.http.post) as post_mock:
+            channel.publish('event', data)
+            _, kwargs = post_mock.call_args
+            raw_data = json.loads(self.decode(kwargs['body'])['data'])
+            self.assertEqual(raw_data, data)
+            self.assertEqual(self.decode(kwargs['body'])['encoding'].strip('/'),
+                             'json')
+
+    def test_with_json_list_data(self):
+        channel = self.ably.channels["persisted:publish"]
+        data = [six.u('foó'), six.u('bár')]
+        with mock.patch('ably.rest.rest.Http.post',
+                        wraps=channel.ably.http.post) as post_mock:
+            channel.publish('event', data)
+            _, kwargs = post_mock.call_args
+            raw_data = json.loads(self.decode(kwargs['body'])['data'])
+            self.assertEqual(raw_data, data)
+            self.assertEqual(self.decode(kwargs['body'])['encoding'].strip('/'),
+                             'json')
+
+    def test_text_utf8_decode(self):
+        channel = self.ably.channels["persisted:stringdecode-bin"]
+
+        channel.publish('event', six.u('fóo'))
+        message = channel.history().items[0]
+        self.assertEqual(message.data, six.u('fóo'))
+        self.assertIsInstance(message.data, six.text_type)
+        self.assertFalse(message.encoding)
+
+    def test_with_binary_type_decode(self):
+        channel = self.ably.channels["persisted:binarydecode-bin"]
+
+        channel.publish('event', six.b('foob'))
+        message = channel.history().items[0]
+        self.assertEqual(message.data, six.b('foob'))
+        self.assertIsInstance(message.data, six.binary_type)
+        self.assertFalse(message.encoding)
+
+    def test_with_json_dict_data_decode(self):
+        channel = self.ably.channels["persisted:jsondict-bin"]
+        data = {six.u('foó'): six.u('bár')}
+        channel.publish('event', data)
+        message = channel.history().items[0]
+        self.assertEqual(message.data, data)
+        self.assertFalse(message.encoding)
+
+    def test_with_json_list_data_decode(self):
+        channel = self.ably.channels["persisted:jsonarray-bin"]
+        data = [six.u('foó'), six.u('bár')]
+        channel.publish('event', data)
+        message = channel.history().items[0]
+        self.assertEqual(message.data, data)
+        self.assertFalse(message.encoding)
+
+
+class TesBinaryEncodersEncryption(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                            host=test_vars["host"],
+                            port=test_vars["port"],
+                            tls_port=test_vars["tls_port"],
+                            tls=test_vars["tls"],
+                            use_text_protocol=False)
+        cls.cipher_params = CipherParams(secret_key='keyfordecrypt_16',
+                                         algorithm='aes')
+
+    def decrypt(self, payload, options={}):
+        cipher = get_cipher(get_default_params('keyfordecrypt_16'))
+        return cipher.decrypt(payload)
+
+    def decode(self, data):
+        return msgpack.unpackb(data, encoding='utf-8')
+
+    def test_text_utf8(self):
+        channel = self.ably.channels.get("persisted:publish_enc",
+                                         options=ChannelOptions(
+                                            encrypted=True,
+                                            cipher_params=self.cipher_params))
+        with mock.patch('ably.rest.rest.Http.post',
+                        wraps=channel.ably.http.post) as post_mock:
+            channel.publish('event', six.u('fóo'))
+            _, kwargs = post_mock.call_args
+            self.assertEquals(self.decode(kwargs['body'])['encoding'].strip('/'),
+                              'utf-8/cipher+aes-128-cbc')
+            data = self.decrypt(self.decode(kwargs['body'])['data']).decode('utf-8')
+            self.assertEquals(data, six.u('fóo'))
+
+    def test_with_binary_type(self):
+        channel = self.ably.channels.get("persisted:publish_enc",
+                                         options=ChannelOptions(
+                                            encrypted=True,
+                                            cipher_params=self.cipher_params))
+
+        with mock.patch('ably.rest.rest.Http.post',
+                        wraps=channel.ably.http.post) as post_mock:
+            channel.publish('event', six.b('foo'))
+            _, kwargs = post_mock.call_args
+
+            self.assertEquals(self.decode(kwargs['body'])['encoding'].strip('/'),
+                              'cipher+aes-128-cbc')
+            data = self.decrypt(self.decode(kwargs['body'])['data'])
+            self.assertEqual(data, six.b('foo'))
+            self.assertIsInstance(data, six.binary_type)
+
+    def test_with_json_dict_data(self):
+        channel = self.ably.channels.get("persisted:publish_enc",
+                                         options=ChannelOptions(
+                                            encrypted=True,
+                                            cipher_params=self.cipher_params))
+        data = {six.u('foó'): six.u('bár')}
+        with mock.patch('ably.rest.rest.Http.post',
+                        wraps=channel.ably.http.post) as post_mock:
+            channel.publish('event', data)
+            _, kwargs = post_mock.call_args
+            self.assertEquals(self.decode(kwargs['body'])['encoding'].strip('/'),
+                              'json/utf-8/cipher+aes-128-cbc')
+            raw_data = self.decrypt(self.decode(kwargs['body'])['data']).decode('ascii')
+            self.assertEqual(json.loads(raw_data), data)
+
+    def test_with_json_list_data(self):
+        channel = self.ably.channels.get("persisted:publish_enc",
+                                         options=ChannelOptions(
+                                            encrypted=True,
+                                            cipher_params=self.cipher_params))
+        data = [six.u('foó'), six.u('bár')]
+        with mock.patch('ably.rest.rest.Http.post',
+                        wraps=channel.ably.http.post) as post_mock:
+            channel.publish('event', data)
+            _, kwargs = post_mock.call_args
+            self.assertEquals(self.decode(kwargs['body'])['encoding'].strip('/'),
+                              'json/utf-8/cipher+aes-128-cbc')
+            raw_data = self.decrypt(self.decode(kwargs['body'])['data']).decode('ascii')
+            self.assertEqual(json.loads(raw_data), data)
+
+    def test_text_utf8_decode(self):
+        channel = self.ably.channels.get("persisted:enc_stringdecode-bin",
+                                         options=ChannelOptions(
+                                            encrypted=True,
+                                            cipher_params=self.cipher_params))
+        channel.publish('event', six.u('foó'))
+        message = channel.history().items[0]
+        self.assertEqual(message.data, six.u('foó'))
+        self.assertIsInstance(message.data, six.text_type)
+        self.assertFalse(message.encoding)
+
+    def test_with_binary_type_decode(self):
+        channel = self.ably.channels.get("persisted:enc_binarydecode-bin",
+                                         options=ChannelOptions(
+                                            encrypted=True,
+                                            cipher_params=self.cipher_params))
+
+        channel.publish('event', six.b('foob'))
+        message = channel.history().items[0]
+        self.assertEqual(message.data, six.b('foob'))
+        self.assertIsInstance(message.data, six.binary_type)
+        self.assertFalse(message.encoding)
+
+    def test_with_json_dict_data_decode(self):
+        channel = self.ably.channels.get("persisted:enc_jsondict-bin",
+                                         options=ChannelOptions(
+                                            encrypted=True,
+                                            cipher_params=self.cipher_params))
+        data = {six.u('foó'): six.u('bár')}
+        channel.publish('event', data)
+        message = channel.history().items[0]
+        self.assertEqual(message.data, data)
+        self.assertFalse(message.encoding)
+
+    def test_with_json_list_data_decode(self):
+        channel = self.ably.channels.get("persisted:enc_list-bin",
                                          options=ChannelOptions(
                                             encrypted=True,
                                             cipher_params=self.cipher_params))

--- a/test/ably/encoders_test.py
+++ b/test/ably/encoders_test.py
@@ -28,7 +28,7 @@ class TestTextEncodersNoEncryption(unittest.TestCase):
                             port=test_vars["port"],
                             tls_port=test_vars["tls_port"],
                             tls=test_vars["tls"],
-                            use_text_protocol=True)
+                            use_binary_protocol=False)
 
     def test_text_utf8(self):
         channel = self.ably.channels["persisted:publish"]
@@ -124,7 +124,7 @@ class TestTextEncodersEncryption(unittest.TestCase):
                             port=test_vars["port"],
                             tls_port=test_vars["tls_port"],
                             tls=test_vars["tls"],
-                            use_text_protocol=True)
+                            use_binary_protocol=False)
         cls.cipher_params = CipherParams(secret_key='keyfordecrypt_16',
                                          algorithm='aes')
 
@@ -243,8 +243,7 @@ class TestBinaryEncodersNoEncryption(unittest.TestCase):
                             host=test_vars["host"],
                             port=test_vars["port"],
                             tls_port=test_vars["tls_port"],
-                            tls=test_vars["tls"],
-                            use_text_protocol=False)
+                            tls=test_vars["tls"])
 
     def decode(self, data):
         return msgpack.unpackb(data, encoding='utf-8')
@@ -335,8 +334,7 @@ class TesBinaryEncodersEncryption(unittest.TestCase):
                             host=test_vars["host"],
                             port=test_vars["port"],
                             tls_port=test_vars["tls_port"],
-                            tls=test_vars["tls"],
-                            use_text_protocol=False)
+                            tls=test_vars["tls"])
         cls.cipher_params = CipherParams(secret_key='keyfordecrypt_16',
                                          algorithm='aes')
 

--- a/test/ably/encoders_test.py
+++ b/test/ably/encoders_test.py
@@ -327,7 +327,7 @@ class TestBinaryEncodersNoEncryption(unittest.TestCase):
         self.assertFalse(message.encoding)
 
 
-class TesBinaryEncodersEncryption(unittest.TestCase):
+class TestBinaryEncodersEncryption(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],

--- a/test/ably/restchannelhistory_test.py
+++ b/test/ably/restchannelhistory_test.py
@@ -1,19 +1,16 @@
 from __future__ import absolute_import
 
-import math
-from datetime import datetime
-from datetime import timedelta
 import logging
 import time
 import unittest
 
 import responses
 import six
+import msgpack
 from six.moves import range
 
 from ably import AblyException
 from ably import AblyRest
-from ably import Options
 from ably.http.paginatedresult import PaginatedResult
 
 from test.ably.restsetup import RestSetup
@@ -126,7 +123,7 @@ class TestRestChannelHistory(unittest.TestCase):
     def test_channel_history_default_limit(self):
         channel = TestRestChannelHistory.ably.channels['persisted:channelhistory_limit']
         url = self.history_mock_url('persisted:channelhistory_limit')
-        responses.add(responses.GET, url, body='{}')
+        responses.add(responses.GET, url, body=msgpack.packb({}))
         channel.history()
         self.assertNotIn('limit=', responses.calls[0].request.url.split('?')[-1])
 
@@ -134,7 +131,7 @@ class TestRestChannelHistory(unittest.TestCase):
     def test_channel_history_with_limits(self):
         channel = TestRestChannelHistory.ably.channels['persisted:channelhistory_limit']
         url = self.history_mock_url('persisted:channelhistory_limit')
-        responses.add(responses.GET, url, body='{}')
+        responses.add(responses.GET, url, body=msgpack.packb({}))
         channel.history(limit=500)
         self.assertIn('limit=500', responses.calls[0].request.url.split('?')[-1])
         channel.history(limit=1000)

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -27,14 +27,13 @@ class TestRestChannelPublish(unittest.TestCase):
                             port=test_vars["port"],
                             tls_port=test_vars["tls_port"],
                             tls=test_vars["tls"],
-                            use_text_protocol=True)
+                            use_binary_protocol=False)
 
         cls.ably_binary = AblyRest(key=test_vars["keys"][0]["key_str"],
                                    host=test_vars["host"],
                                    port=test_vars["port"],
                                    tls_port=test_vars["tls_port"],
-                                   tls=test_vars["tls"],
-                                   use_text_protocol=False)
+                                   tls=test_vars["tls"])
 
     def test_publish_various_datatypes_text(self):
         publish0 = TestRestChannelPublish.ably.channels["persisted:publish0"]
@@ -151,8 +150,7 @@ class TestRestChannelPublish(unittest.TestCase):
                         host=test_vars["host"],
                         port=test_vars["port"],
                         tls_port=test_vars["tls_port"],
-                        tls=test_vars["tls"],
-                        use_text_protocol=True)
+                        tls=test_vars["tls"])
         ably.auth.authorise(token_params=token_params)
 
         with self.assertRaises(AblyException) as cm:

--- a/test/ably/restcrypto_test.py
+++ b/test/ably/restcrypto_test.py
@@ -31,7 +31,7 @@ class TestRestCrypto(unittest.TestCase):
             "port": test_vars["port"],
             "tls_port": test_vars["tls_port"],
             "tls": test_vars["tls"],
-            "use_text_protocol": True
+            "use_binary_protocol": False
         }
         cls.ably = AblyRest(**options)
         cls.ably2 = AblyRest(**options)

--- a/test/ably/restcrypto_test.py
+++ b/test/ably/restcrypto_test.py
@@ -241,7 +241,7 @@ class AbstractTestCryptoWithFixture(object):
     def test_decode(self):
         for item in self.items:
             self.assertEqual(item['encoded']['name'], item['encrypted']['name'])
-            message = Message.from_json(item['encrypted'], self.cipher)
+            message = Message.from_dict(item['encrypted'], self.cipher)
             self.assertEqual(message.encoding, '')
             expected_data = self.get_encoded(item['encoded'])
             self.assertEqual(expected_data, message.data)

--- a/test/ably/restpresence_test.py
+++ b/test/ably/restpresence_test.py
@@ -2,21 +2,85 @@
 
 from __future__ import absolute_import
 
-import six
+import json
 import unittest
 from datetime import datetime, timedelta
+from functools import wraps
 
+import six
+import mock
+import msgpack
 import responses
 
 from ably import AblyRest
 from ably.http.paginatedresult import PaginatedResult
-from ably.types.presence import PresenceMessage
-from ably import ChannelOptions, CipherParams
-from ably.util.crypto import get_default_params, get_cipher
+from ably.types.presence import (PresenceMessage, make_presence_response_handler,
+                                 make_encrypted_presence_response_handler)
+from ably import ChannelOptions
+from ably.util.crypto import get_default_params
 
 from test.ably.restsetup import RestSetup
 
 test_vars = RestSetup.get_test_vars()
+
+
+def assert_responses_types(types):
+    """
+    This code is a bit complicated but saves a lot of coding.
+    It is a decorator to check if we retrieved presence with the correct protocol.
+    usage:
+
+    @assert_responses_types(['json', 'msgpack'])
+    def test_something(self):
+        ...
+
+    this will check if we receive two responses, the first using json and the
+    second msgpack
+    """
+    responses = []
+
+    def presence_side_effect(binary):
+        def handler(response):
+            responses.append(response)
+            return make_presence_response_handler(binary)(response)
+        return handler
+
+    def encrypted_side_effect(cipher, binary):
+        def handler(response):
+            responses.append(response)
+            return make_encrypted_presence_response_handler(cipher, binary)(response)
+        return handler
+
+    def patch_handlers():
+            p1 = mock.patch('ably.types.presence.make_presence_response_handler',
+                            side_effect=presence_side_effect)
+            p2 = mock.patch('ably.types.presence.make_encrypted_presence_response_handler',
+                            side_effect=encrypted_side_effect)
+            p1.start()
+            p2.start()
+            return p1, p2
+
+    def unpatch_handlers(patchers):
+        for patcher in patchers:
+            patcher.stop()
+
+    def test_decorator(fn):
+        @wraps(fn)
+        def test_decorated(self, *args, **kwargs):
+            patchers = patch_handlers()
+            fn(self, *args, **kwargs)
+            unpatch_handlers(patchers)
+            self.assertEquals(len(types), len(responses))
+            for type_name, response in zip(types, responses):
+                if type_name == 'json':
+                    self.assertEquals(response.headers['content-type'], 'application/json')
+                    json.loads(response.text)
+                else:
+                    self.assertEquals(response.headers['content-type'], 'application/x-msgpack')
+                    msgpack.unpackb(response.content, encoding='utf-8')
+
+        return test_decorated
+    return test_decorator
 
 
 class TestPresence(unittest.TestCase):
@@ -27,87 +91,107 @@ class TestPresence(unittest.TestCase):
                              port=test_vars["port"],
                              tls_port=test_vars["tls_port"],
                              tls=test_vars["tls"])
+        self.ably_bin = AblyRest(test_vars["keys"][0]["key_str"],
+                                 host=test_vars["host"],
+                                 port=test_vars["port"],
+                                 tls_port=test_vars["tls_port"],
+                                 tls=test_vars["tls"],
+                                 use_text_protocol=False)
         self.channel = self.ably.channels.get('persisted:presence_fixtures')
+        self.channel_bin = self.ably_bin.channels.get('persisted:presence_fixtures')
+        self.channels = [self.channel, self.channel_bin]
 
+    @assert_responses_types(['json', 'msgpack'])
     def test_channel_presence_get(self):
-        presence_page = self.channel.presence.get()
-        self.assertIsInstance(presence_page, PaginatedResult)
-        self.assertEqual(len(presence_page.items), 6)
-        member = presence_page.items[0]
-        self.assertIsInstance(member, PresenceMessage)
-        self.assertTrue(member.action)
-        self.assertTrue(member.id)
-        self.assertTrue(member.client_id)
-        self.assertTrue(member.data)
-        self.assertTrue(member.connection_id)
-        self.assertTrue(member.timestamp)
+        for channel in self.channels:
+            presence_page = channel.presence.get()
+            self.assertIsInstance(presence_page, PaginatedResult)
+            self.assertEqual(len(presence_page.items), 6)
+            member = presence_page.items[0]
+            self.assertIsInstance(member, PresenceMessage)
+            self.assertTrue(member.action)
+            self.assertTrue(member.id)
+            self.assertTrue(member.client_id)
+            self.assertTrue(member.data)
+            self.assertTrue(member.connection_id)
+            self.assertTrue(member.timestamp)
 
+    @assert_responses_types(['json', 'msgpack'])
     def test_channel_presence_history(self):
-        presence_history = self.channel.presence.history()
-        self.assertIsInstance(presence_history, PaginatedResult)
-        self.assertEqual(len(presence_history.items), 6)
-        member = presence_history.items[0]
-        self.assertIsInstance(member, PresenceMessage)
-        self.assertTrue(member.action)
-        self.assertTrue(member.id)
-        self.assertTrue(member.client_id)
-        self.assertTrue(member.data)
-        self.assertTrue(member.connection_id)
-        self.assertTrue(member.timestamp)
-        self.assertTrue(member.encoding)
+        for channel in self.channels:
+            presence_history = channel.presence.history()
+            self.assertIsInstance(presence_history, PaginatedResult)
+            self.assertEqual(len(presence_history.items), 6)
+            member = presence_history.items[0]
+            self.assertIsInstance(member, PresenceMessage)
+            self.assertTrue(member.action)
+            self.assertTrue(member.id)
+            self.assertTrue(member.client_id)
+            self.assertTrue(member.data)
+            self.assertTrue(member.connection_id)
+            self.assertTrue(member.timestamp)
+            self.assertTrue(member.encoding)
 
+    @assert_responses_types(['json', 'msgpack'])
     def test_presence_get_encoded(self):
-        presence_history = self.channel.presence.history()
-        self.assertEqual(presence_history.items[-1].data, six.u("true"))
-        self.assertEqual(presence_history.items[-2].data, six.u("24"))
-        self.assertEqual(presence_history.items[-3].data,
-                         six.u("This is a string clientData payload"))
-        # this one doesn't have encoding field
-        self.assertEqual(presence_history.items[-4].data,
-                         six.u('{ "test": "This is a JSONObject clientData payload"}'))
-        self.assertEqual(presence_history.items[-5].data,
-                         {"example": {"json": "Object"}})
+        for channel in self.channels:
+            presence_history = channel.presence.history()
+            self.assertEqual(presence_history.items[-1].data, six.u("true"))
+            self.assertEqual(presence_history.items[-2].data, six.u("24"))
+            self.assertEqual(presence_history.items[-3].data,
+                             six.u("This is a string clientData payload"))
+            # this one doesn't have encoding field
+            self.assertEqual(presence_history.items[-4].data,
+                             six.u('{ "test": "This is a JSONObject clientData payload"}'))
+            self.assertEqual(presence_history.items[-5].data,
+                             {"example": {"json": "Object"}})
 
+    @assert_responses_types(['json', 'msgpack'])
     def test_presence_history_encrypted(self):
-        ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                        host=test_vars["host"],
-                        port=test_vars["port"],
-                        tls_port=test_vars["tls_port"],
-                        tls=test_vars["tls"],
-                        use_text_protocol=True)
-        params = get_default_params('0123456789abcdef')
-        self.channel = ably.channels.get('persisted:presence_fixtures',
-                                         options=ChannelOptions(
-                                            encrypted=True,
-                                            cipher_params=params))
-        presence_history = self.channel.presence.history()
-        self.assertEqual(presence_history.items[0].data,
-                         {'foo': 'bar'})
+        for use_text_protocol in [True, False]:
+            ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                            host=test_vars["host"],
+                            port=test_vars["port"],
+                            tls_port=test_vars["tls_port"],
+                            tls=test_vars["tls"],
+                            use_text_protocol=use_text_protocol)
+            params = get_default_params('0123456789abcdef')
+            self.channel = ably.channels.get('persisted:presence_fixtures',
+                                             options=ChannelOptions(
+                                                encrypted=True,
+                                                cipher_params=params))
+            presence_history = self.channel.presence.history()
+            self.assertEqual(presence_history.items[0].data,
+                             {'foo': 'bar'})
 
+    @assert_responses_types(['json', 'msgpack'])
     def test_presence_get_encrypted(self):
-        ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                        host=test_vars["host"],
-                        port=test_vars["port"],
-                        tls_port=test_vars["tls_port"],
-                        tls=test_vars["tls"],
-                        use_text_protocol=True)
-        params = get_default_params('0123456789abcdef')
-        self.channel = ably.channels.get('persisted:presence_fixtures',
-                                         options=ChannelOptions(
-                                            encrypted=True,
-                                            cipher_params=params))
-        presence_messages = self.channel.presence.get()
-        message = list(filter(
-            lambda message: message.client_id == 'client_encoded',
-            presence_messages.items))[0]
+        for use_text_protocol in [True, False]:
+            ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                            host=test_vars["host"],
+                            port=test_vars["port"],
+                            tls_port=test_vars["tls_port"],
+                            tls=test_vars["tls"],
+                            use_text_protocol=use_text_protocol)
+            params = get_default_params('0123456789abcdef')
+            self.channel = ably.channels.get('persisted:presence_fixtures',
+                                             options=ChannelOptions(
+                                                encrypted=True,
+                                                cipher_params=params))
+            presence_messages = self.channel.presence.get()
+            message = list(filter(
+                lambda message: message.client_id == 'client_encoded',
+                presence_messages.items))[0]
 
-        self.assertEqual(message.data, {'foo': 'bar'})
+            self.assertEqual(message.data, {'foo': 'bar'})
 
+    @assert_responses_types(['json'])
     def test_timestamp_is_datetime(self):
         presence_page = self.channel.presence.get()
         member = presence_page.items[0]
         self.assertIsInstance(member.timestamp, datetime)
 
+    @assert_responses_types(['json'])
     def test_presence_message_has_correct_member_key(self):
         presence_page = self.channel.presence.get()
         member = presence_page.items[0]
@@ -140,7 +224,6 @@ class TestPresence(unittest.TestCase):
             kwargs['port_sufix'] = ':' + str(port)
         url = '{scheme}://{host}{port_sufix}/channels/persisted%3Apresence_fixtures/presence/history'
         return url.format(**kwargs)
-
 
     @responses.activate
     def test_get_presence_default_limit(self):

--- a/test/ably/restpresence_test.py
+++ b/test/ably/restpresence_test.py
@@ -90,13 +90,13 @@ class TestPresence(unittest.TestCase):
                              host=test_vars["host"],
                              port=test_vars["port"],
                              tls_port=test_vars["tls_port"],
-                             tls=test_vars["tls"])
+                             tls=test_vars["tls"],
+                             use_binary_protocol=False)
         self.ably_bin = AblyRest(test_vars["keys"][0]["key_str"],
                                  host=test_vars["host"],
                                  port=test_vars["port"],
                                  tls_port=test_vars["tls_port"],
-                                 tls=test_vars["tls"],
-                                 use_text_protocol=False)
+                                 tls=test_vars["tls"])
         self.channel = self.ably.channels.get('persisted:presence_fixtures')
         self.channel_bin = self.ably_bin.channels.get('persisted:presence_fixtures')
         self.channels = [self.channel, self.channel_bin]
@@ -148,13 +148,13 @@ class TestPresence(unittest.TestCase):
 
     @assert_responses_types(['json', 'msgpack'])
     def test_presence_history_encrypted(self):
-        for use_text_protocol in [True, False]:
+        for use_binary_protocol in [False, True]:
             ably = AblyRest(key=test_vars["keys"][0]["key_str"],
                             host=test_vars["host"],
                             port=test_vars["port"],
                             tls_port=test_vars["tls_port"],
                             tls=test_vars["tls"],
-                            use_text_protocol=use_text_protocol)
+                            use_binary_protocol=use_binary_protocol)
             params = get_default_params('0123456789abcdef')
             self.channel = ably.channels.get('persisted:presence_fixtures',
                                              options=ChannelOptions(
@@ -166,13 +166,13 @@ class TestPresence(unittest.TestCase):
 
     @assert_responses_types(['json', 'msgpack'])
     def test_presence_get_encrypted(self):
-        for use_text_protocol in [True, False]:
+        for use_binary_protocol in [False, True]:
             ably = AblyRest(key=test_vars["keys"][0]["key_str"],
                             host=test_vars["host"],
                             port=test_vars["port"],
                             tls_port=test_vars["tls_port"],
                             tls=test_vars["tls"],
-                            use_text_protocol=use_text_protocol)
+                            use_binary_protocol=use_binary_protocol)
             params = get_default_params('0123456789abcdef')
             self.channel = ably.channels.get('persisted:presence_fixtures',
                                              options=ChannelOptions(


### PR DESCRIPTION
Addresses the following

* (RSC8) Supports two protocols:
  * (RSC8a) MessagePack binary protocol (this is the default for environments having a suitable level or support for binary data), see http://msgpack.org/ for more info
  * (RSC8b) JSON text protocol (used when useBinaryProtocol option is false)


* (RSL4) Message encoding
  * (RSL4c) When using MessagePack Message encoding
    * (RSL4c1) a binary Message payload is encoded as MessagePack binary type
    * (RSL4c2) a string Message payload is encoded as MessagePack string type
    * (RSL4c3) a JSON Message payload is stringified either as a JSON Object or Array and encoded as MessagePack string type and the encoding attribute is set to “json”
    * (RSL4c4) All messages received will deliver payloads in the format they were sent in i.e. binary, string, or a structured type containing the parsed JSON

* (TO3) The attributes of ClientOptions consist of:
  * (TO3f) useBinaryProtocol boolean – defaults to true. If false, forces the library to use the JSON encoding for REST and Realtime operations, instead of the default binary msgpack encoding