### PR TITLE
Now when sending binary data messages one should use bytearray

### DIFF
--- a/ably/types/message.py
+++ b/ably/types/message.py
@@ -116,15 +116,15 @@ class Message(EncodeDataMixin):
         if isinstance(data, dict) or isinstance(data, list):
             encoding.append('json')
             data = json.dumps(data)
-
-        elif isinstance(self.data, six.binary_type) and not binary:
+        elif isinstance(data, six.text_type) and not binary:
+            # text_type is always a unicode string
+            pass
+        elif (not binary and isinstance(data, bytearray) or
+              # bytearray is always bytes
+              isinstance(data, six.binary_type) and six.binary_type != str):
+                # in py3k we will understand <class 'bytes'> as bytes
             data = base64.b64encode(data).decode('ascii')
             encoding.append('base64')
-        elif isinstance(data, six.text_type) and not binary:
-            encoding.append('utf-8')
-        elif isinstance(data, (six.text_type, six.binary_type)):
-            # only if is binary
-            pass
         elif isinstance(data, CipherData):
             encoding.append(data.encoding_str)
             data_type = data.type
@@ -133,8 +133,11 @@ class Message(EncodeDataMixin):
                 encoding.append('base64')
             else:
                 data = data.buffer
+        elif binary and isinstance(data, bytearray):
+            data = six.binary_type(data)
 
-        if not (isinstance(data, (six.binary_type, six.text_type, list, dict)) or
+        if not (isinstance(data, (six.binary_type, six.text_type, list, dict,
+                                  bytearray)) or
                 data is None):
             raise AblyException("Invalid data payload", 400, 40011)
 

--- a/ably/types/mixins.py
+++ b/ably/types/mixins.py
@@ -21,6 +21,8 @@ class EncodeDataMixin(object):
 
         while encoding_list:
             encoding = encoding_list.pop()
+            if not encoding:
+                continue
             if encoding == 'json':
                 if isinstance(data, six.binary_type):
                     data = data.decode()
@@ -28,9 +30,9 @@ class EncodeDataMixin(object):
                     continue
                 data = json.loads(data)
             elif encoding == 'base64' and isinstance(data, six.binary_type):
-                data = base64.b64decode(data)
+                data = bytearray(base64.b64decode(data))
             elif encoding == 'base64':
-                data = base64.b64decode(data.encode('utf-8'))
+                data = bytearray(base64.b64decode(data.encode('utf-8')))
             elif encoding.startswith('%s+' % CipherData.ENCODING_ID):
                 if not cipher:
                     log.error('Message cannot be decrypted as the channel is '
@@ -38,7 +40,8 @@ class EncodeDataMixin(object):
                     encoding_list.append(encoding)
                     break
                 data = cipher.decrypt(data)
-            elif encoding == 'utf-8' and isinstance(data, six.binary_type):
+            elif encoding == 'utf-8' and isinstance(data, (six.binary_type,
+                                                           bytearray)):
                 data = data.decode('utf-8')
             elif encoding == 'utf-8':
                 pass

--- a/ably/types/typedbuffer.py
+++ b/ably/types/typedbuffer.py
@@ -65,7 +65,7 @@ class TypedBuffer(object):
 
         if isinstance(obj, TypedBuffer):
             return obj
-        elif isinstance(obj, six.binary_type):
+        elif isinstance(obj, (six.binary_type, bytearray)):
             type = DataType.BUFFER
             buffer = obj
         elif isinstance(obj, six.string_types):

--- a/ably/util/crypto.py
+++ b/ably/util/crypto.py
@@ -90,17 +90,21 @@ class CbcChannelCipher(object):
         return rndfile.read(length)
 
     def encrypt(self, plaintext):
+        if isinstance(plaintext, bytearray):
+            plaintext = six.binary_type(plaintext)
         padded_plaintext = self.__pad(plaintext)
         encrypted = self.__iv + self.__encryptor.encrypt(padded_plaintext)
         self.__iv = encrypted[-self.__block_size:]
         return encrypted
 
     def decrypt(self, ciphertext):
+        if isinstance(ciphertext, bytearray):
+            ciphertext = six.binary_type(ciphertext)
         iv = ciphertext[:self.__block_size]
         ciphertext = ciphertext[self.__block_size:]
         decryptor = AES.new(self.__secret_key, AES.MODE_CBC, iv)
         decrypted = decryptor.decrypt(ciphertext)
-        return self.__unpad(decrypted)
+        return bytearray(self.__unpad(decrypted))
 
     @property
     def secret_key(self):


### PR DESCRIPTION
Now when sending binary data messages one should use bytearray, this way there is no ambiguity, on python2, about byte/str.

The idea here is to use bytearray objects when sending bytes on python2.
This will have to be well documented as the user might have to convert from bytes to bytearray before sending data, else it will end up sending as string.