### PR TITLE
Done with stats, as well as varying every test to each protocol (G1)

### DIFF
--- a/ably/http/http.py
+++ b/ably/http/http.py
@@ -4,11 +4,13 @@ import functools
 import itertools
 import logging
 import time
+import json
 
 from six.moves import range
 from six.moves.urllib.parse import urljoin
 
 import requests
+import msgpack
 
 from ably.rest.auth import Auth
 from ably.http.httputils import HttpUtils
@@ -68,6 +70,25 @@ class Request(object):
         return self.__skip_auth
 
 
+class Response(object):
+    """
+    Composition for requests.Response with delegation
+    """
+
+    def __init__(self, response, binary=False):
+        self.__response = response
+        self.__binary = binary
+
+    def to_native(self):
+        if self.__binary:
+            return msgpack.unpackb(self.__response.content, encoding='utf-8')
+        else:
+            return self.json()
+
+    def __getattr__(self, attr):
+        return getattr(self.__response, attr)
+
+
 class Http(object):
     CONNECTION_RETRY = {
         'single_request_connect_timeout': 4,
@@ -84,14 +105,30 @@ class Http(object):
         self.__session = requests.Session()
         self.__auth = None
 
+    def dump_body(self, body):
+        if self.options.use_binary_protocol:
+            return msgpack.packb(body, use_bin_type=False)
+        else:
+            return json.dumps(body, separators=(',', ':'))
+
     @reauth_if_expired
-    def make_request(self, method, path, headers=None, body=None, skip_auth=False, timeout=None):
+    def make_request(self, method, path, headers=None, body=None,
+                     native_data=None, skip_auth=False, timeout=None):
         fallback_hosts = Defaults.get_fallback_hosts(self.__options)
         if fallback_hosts:
             fallback_hosts.insert(0, self.preferred_host)
             fallback_hosts = itertools.cycle(fallback_hosts)
+        if native_data is not None and body is not None:
+            raise ValueError("make_request takes either body or native_data")
+        elif native_data is not None:
+            body = self.dump_body(native_data)
+        if body:
+            all_headers = HttpUtils.default_post_headers(
+                self.options.use_binary_protocol)
+        else:
+            all_headers = HttpUtils.default_get_headers(
+                self.options.use_binary_protocol)
 
-        all_headers = headers or {}
         if not skip_auth:
             if self.auth.auth_method == Auth.Method.BASIC and self.preferred_scheme.lower() == 'http':
                 raise AblyException(
@@ -99,6 +136,8 @@ class Http(object):
                     401,
                     40103)
             all_headers.update(self.auth._get_auth_headers())
+        if headers:
+            all_headers.update(headers)
 
         single_request_connect_timeout = self.CONNECTION_RETRY['single_request_connect_timeout']
         single_request_read_timeout = self.CONNECTION_RETRY['single_request_read_timeout']
@@ -134,7 +173,7 @@ class Http(object):
             else:
                 try:
                     AblyException.raise_for_response(response)
-                    return response
+                    return Response(response, self.options.use_binary_protocol)
                 except AblyException as e:
                     if not e.is_server_error:
                         raise e
@@ -145,8 +184,9 @@ class Http(object):
     def get(self, url, headers=None, skip_auth=False, timeout=None):
         return self.make_request('GET', url, headers=headers, skip_auth=skip_auth, timeout=timeout)
 
-    def post(self, url, headers=None, body=None, skip_auth=False, timeout=None):
-        return self.make_request('POST', url, headers=headers, body=body, skip_auth=skip_auth, timeout=timeout)
+    def post(self, url, headers=None, body=None, native_data=None, skip_auth=False, timeout=None):
+        return self.make_request('POST', url, headers=headers, body=body, native_data=native_data,
+                                 skip_auth=skip_auth, timeout=timeout)
 
     def delete(self, url, headers=None, skip_auth=False, timeout=None):
         return self.make_request('DELETE', url, headers=headers, skip_auth=skip_auth, timeout=timeout)

--- a/ably/http/httputils.py
+++ b/ably/http/httputils.py
@@ -8,29 +8,29 @@ class HttpUtils(object):
         "json": "application/json",
         "xml": "application/xml",
         "html": "text/html",
-        # "binary": "application/x-thrift",
+        "binary": "application/x-msgpack",
     }
 
     @staticmethod
     def default_get_headers(binary=False):
         if binary:
             return {
-                "Accept": "application/x-msgpack"
+                "Accept": HttpUtils.mime_types['binary']
             }
         else:
             return {
-                "Accept": "application/json",
+                "Accept": HttpUtils.mime_types['json']
             }
 
     @staticmethod
     def default_post_headers(binary=False):
         if binary:
             return {
-                "Accept": "application/x-msgpack",
-                "Content-Type": "application/x-msgpack"
+                "Accept": HttpUtils.mime_types['binary'],
+                "Content-Type": HttpUtils.mime_types['binary']
             }
         else:
             return {
-                "Accept": "application/json",
-                "Content-Type": "application/json",
+                "Accept": HttpUtils.mime_types['json'],
+                "Content-Type": HttpUtils.mime_types['json']
             }

--- a/ably/http/paginatedresult.py
+++ b/ably/http/paginatedresult.py
@@ -45,9 +45,7 @@ class PaginatedResult(object):
     @staticmethod
     def paginated_query(http, url, headers, response_processor):
         headers = headers or {}
-        all_headers = HttpUtils.default_get_headers(http.options.use_binary_protocol)
-        all_headers.update(headers)
-        req = Request(method='GET', url=url, headers=all_headers, body=None, skip_auth=True)
+        req = Request(method='GET', url=url, headers=headers, body=None, skip_auth=True)
         return PaginatedResult.paginated_query_with_request(http, req, response_processor)
 
     @staticmethod

--- a/ably/http/paginatedresult.py
+++ b/ably/http/paginatedresult.py
@@ -45,7 +45,7 @@ class PaginatedResult(object):
     @staticmethod
     def paginated_query(http, url, headers, response_processor):
         headers = headers or {}
-        req = Request(method='GET', url=url, headers=headers, body=None, skip_auth=True)
+        req = Request(method='GET', url=url, headers=headers, body=None, skip_auth=False)
         return PaginatedResult.paginated_query_with_request(http, req, response_processor)
 
     @staticmethod

--- a/ably/rest/auth.py
+++ b/ably/rest/auth.py
@@ -101,10 +101,7 @@ class Auth(object):
         auth_token = auth_token or self.auth_options.auth_token
         auth_callback = auth_callback or self.auth_options.auth_callback
         auth_url = auth_url or self.auth_options.auth_url
-        auth_headers = auth_headers or {
-            "Content-Encoding": "utf-8",
-            "Content-Type": "application/json",
-        }
+
         auth_params = auth_params or self.auth_params
 
         token_params = token_params or {}
@@ -122,7 +119,7 @@ class Auth(object):
             response = self.ably.http.post(
                 auth_url,
                 headers=auth_headers,
-                body=json.dumps(token_params),
+                native_data=token_params,
                 skip_auth=True
             )
 
@@ -144,17 +141,18 @@ class Auth(object):
                 40000)
 
         token_path = "/keys/%s/requestToken" % key_name
+
         response = self.ably.http.post(
             token_path,
             headers=auth_headers,
-            body=signed_token_request,
+            native_data=signed_token_request,
             skip_auth=True
         )
 
         AblyException.raise_for_response(response)
-        response_json = response.json()
-        log.debug("Token: %s" % str(response_json.get("token")))
-        return TokenDetails.from_dict(response_json)
+        response_dict = response.to_native()
+        log.debug("Token: %s" % str(response_dict.get("token")))
+        return TokenDetails.from_dict(response_dict)
 
     def create_token_request(self, key_name=None, key_secret=None,
                              query_time=None, token_params=None):
@@ -231,7 +229,7 @@ class Auth(object):
 
         req["mac"] = token_params.get("mac")
 
-        signed_request = json.dumps(req)
+        signed_request = req
         log.debug("generated signed request: %s", signed_request)
 
         return signed_request

--- a/ably/rest/channel.py
+++ b/ably/rest/channel.py
@@ -106,11 +106,9 @@ class Channel(object):
                     use_bin_type=True)
 
         path = '/channels/%s/publish' % self.__name
-        headers = HttpUtils.default_post_headers(self.ably.options.use_binary_protocol)
 
         return self.ably.http.post(
             path,
-            headers=headers,
             body=request_body,
             timeout=timeout
             )

--- a/ably/rest/rest.py
+++ b/ably/rest/rest.py
@@ -111,7 +111,7 @@ class AblyRest(object):
         """Returns the current server time in ms since the unix epoch"""
         r = self.http.get('/time', skip_auth=True, timeout=timeout)
         AblyException.raise_for_response(r)
-        return r.json()[0]
+        return r.to_native()[0]
 
     @property
     def client_id(self):

--- a/ably/rest/rest.py
+++ b/ably/rest/rest.py
@@ -11,7 +11,7 @@ from ably.rest.auth import Auth
 from ably.rest.channel import Channels
 from ably.util.exceptions import AblyException, catch_all
 from ably.types.options import Options
-from ably.types.stats import stats_response_processor
+from ably.types.stats import make_stats_response_processor
 
 log = logging.getLogger(__name__)
 
@@ -75,24 +75,32 @@ class AblyRest(object):
 
     @catch_all
     def stats(self, direction=None, start=None, end=None, params=None,
-              limit=None, paginated=None, by=None, timeout=None):
+              limit=None, paginated=None, unit=None, timeout=None):
         """Returns the stats for this application"""
         params = params or {}
 
         if direction:
-            params["direction"] = "%s" % direction
+            params["direction"] = direction
         if start:
             params["start"] = self._format_time_param(start)
         if end:
             params["end"] = self._format_time_param(end)
         if limit:
-            params["limit"] = "%d" % limit
-        if by:
-            params["by"] = "%s" % by
+            if limit > 1000:
+                raise ValueError("The maximum allowed limit is 1000")
+            params["limit"] = limit
+        if unit:
+            params["unit"] = unit
+
+        if 'start' in params and 'end' in params and params['start'] > params['end']:
+            raise ValueError("'end' parameter has to be greater than or equal to 'start'")
 
         url = '/stats'
         if params:
             url += '?' + urlencode(params)
+
+        stats_response_processor = make_stats_response_processor(
+            self.options.use_binary_protocol)
 
         return PaginatedResult.paginated_query(self.http,
                                                url, None,

--- a/ably/types/message.py
+++ b/ably/types/message.py
@@ -196,20 +196,14 @@ class Message(EncodeDataMixin):
 
 def make_message_response_handler(binary):
     def message_response_handler(response):
-        if binary:
-            messages = msgpack.unpackb(response.content, encoding='utf-8')
-        else:
-            messages = response.json()
+        messages = response.to_native()
         return [Message.from_dict(j) for j in messages]
     return message_response_handler
 
 
 def make_encrypted_message_response_handler(cipher, binary):
     def encrypted_message_response_handler(response):
-        if binary:
-            messages = msgpack.unpackb(response.content, encoding='utf-8')
-        else:
-            messages = response.json()
+        messages = response.to_native()
         return [Message.from_dict(j, cipher) for j in messages]
     return encrypted_message_response_handler
 

--- a/ably/types/presence.py
+++ b/ably/types/presence.py
@@ -125,7 +125,6 @@ class Presence(object):
                 raise ValueError("The maximum allowed limit is 1000")
             qs['limit'] = limit
         path = self._path_with_qs('%s/presence' % self.__base_path.rstrip('/'), qs)
-        headers = HttpUtils.default_get_headers(self.__binary)
 
         if self.__cipher:
             presence_handler = make_encrypted_presence_response_handler(self.__cipher, self.__binary)
@@ -135,7 +134,7 @@ class Presence(object):
         return PaginatedResult.paginated_query(
             self.__http,
             path,
-            headers,
+            {},
             presence_handler)
 
     def history(self, limit=None, direction=None, start=None, end=None):
@@ -161,7 +160,6 @@ class Presence(object):
             raise ValueError("'end' parameter has to be greater than or equal to 'start'")
 
         path = self._path_with_qs('%s/presence/history' % self.__base_path.rstrip('/'), qs)
-        headers = HttpUtils.default_get_headers(self.__binary)
 
         if self.__cipher:
             presence_handler = make_encrypted_presence_response_handler(
@@ -172,26 +170,20 @@ class Presence(object):
         return PaginatedResult.paginated_query(
             self.__http,
             path,
-            headers,
+            {},
             presence_handler
         )
 
 
 def make_presence_response_handler(binary):
     def presence_response_handler(response):
-        if binary:
-            messages = msgpack.unpackb(response.content, encoding='utf-8')
-        else:
-            messages = response.json()
+        messages = response.to_native()
         return [PresenceMessage.from_dict(message) for message in messages]
     return presence_response_handler
 
 
 def make_encrypted_presence_response_handler(cipher, binary):
     def encrypted_presence_response_handler(response):
-        if binary:
-            messages = msgpack.unpackb(response.content, encoding='utf-8')
-        else:
-            messages = response.json()
+        messages = response.to_native()
         return [PresenceMessage.from_dict(message, cipher) for message in messages]
     return encrypted_presence_response_handler

--- a/ably/types/presence.py
+++ b/ably/types/presence.py
@@ -2,10 +2,8 @@ from __future__ import absolute_import
 
 from datetime import datetime, timedelta
 
-import msgpack
 from six.moves.urllib.parse import urlencode
 
-from ably.http.httputils import HttpUtils
 from ably.http.paginatedresult import PaginatedResult
 from ably.types.mixins import EncodeDataMixin
 

--- a/ably/types/stats.py
+++ b/ably/types/stats.py
@@ -154,11 +154,7 @@ class Stats(object):
 
 def make_stats_response_processor(binary):
     def stats_response_processor(response):
-        if binary:
-            stats_array = msgpack.unpackb(response.content, encoding='utf-8')
-        else:
-            stats_array = response.json()
-
+        stats_array = response.to_native()
         return Stats.from_array(stats_array)
     return stats_response_processor
 

--- a/ably/types/stats.py
+++ b/ably/types/stats.py
@@ -1,12 +1,15 @@
 from __future__ import absolute_import
 
 import logging
+from datetime import datetime
+
+import msgpack
 
 log = logging.getLogger(__name__)
 
 
 class ResourceCount(object):
-    def __init__(self, opened=0.0, peak=0.0, mean=0.0, min=0.0, refused=0.0):
+    def __init__(self, opened=0, peak=0, mean=0, min=0, refused=0):
         self.opened = opened
         self.peak = peak
         self.mean = mean
@@ -16,22 +19,17 @@ class ResourceCount(object):
     @staticmethod
     def from_dict(rc_dict):
         rc_dict = rc_dict or {}
-        kwargs = {
-            "opened": rc_dict.get("opened"),
-            "peak": rc_dict.get("peak"),
-            "mean": rc_dict.get("mean"),
-            "min": rc_dict.get("min"),
-            "refused": rc_dict.get("refused"),
-        }
+        expected = ['opened', 'peak', 'mean', 'min', 'refused']
+        kwargs = {k: rc_dict[k] for k in rc_dict if (k in expected)}
 
         return ResourceCount(**kwargs)
 
 
 class ConnectionTypes(object):
     def __init__(self, all=None, plain=None, tls=None):
-        self.all = ResourceCount()
-        self.plain = ResourceCount()
-        self.tls = ResourceCount()
+        self.all = all or ResourceCount()
+        self.plain = plain or ResourceCount()
+        self.tls = tls or ResourceCount()
 
     @staticmethod
     def from_dict(ct_dict):
@@ -45,17 +43,15 @@ class ConnectionTypes(object):
 
 
 class MessageCount(object):
-    def __init__(self, count=0.0, data=0.0):
+    def __init__(self, count=0, data=0):
         self.count = count
         self.data = data
 
     @staticmethod
     def from_dict(mc_dict):
         mc_dict = mc_dict or {}
-        kwargs = {
-            "count": mc_dict.get("count"),
-            "data": mc_dict.get("data"),
-        }
+        expected = ['count', 'data']
+        kwargs = {k: mc_dict[k] for k in mc_dict if (k in expected)}
         return MessageCount(**kwargs)
 
 
@@ -77,12 +73,11 @@ class MessageTypes(object):
 
 
 class MessageTraffic(object):
-    def __init__(self, all=None, realtime=None, rest=None, push=None, http_stream=None):
+    def __init__(self, all=None, realtime=None, rest=None, webhook=None):
         self.all = all or MessageTypes()
         self.realtime = realtime or MessageTypes()
         self.rest = rest or MessageTypes()
-        self.push = push or MessageTypes()
-        self.http_stream = http_stream or MessageTypes()
+        self.webhook = webhook or MessageTypes()
 
     @staticmethod
     def from_dict(mt_dict):
@@ -91,14 +86,13 @@ class MessageTraffic(object):
             "all": MessageTypes.from_dict(mt_dict.get("all")),
             "realtime": MessageTypes.from_dict(mt_dict.get("realtime")),
             "rest": MessageTypes.from_dict(mt_dict.get("rest")),
-            "push": MessageTypes.from_dict(mt_dict.get("push")),
-            "http_stream": MessageTypes.from_dict(mt_dict.get("httpStream")),
+            "webhook": MessageTypes.from_dict(mt_dict.get("webhook")),
         }
         return MessageTraffic(**kwargs)
 
 
 class RequestCount(object):
-    def __init__(self, succeeded=0.0, failed=0.0, refused=0.0):
+    def __init__(self, succeeded=0, failed=0, refused=0):
         self.succeeded = succeeded
         self.failed = failed
         self.refused = refused
@@ -106,18 +100,17 @@ class RequestCount(object):
     @staticmethod
     def from_dict(rc_dict):
         rc_dict = rc_dict or {}
-        kwargs = {
-            "succeeded": rc_dict.get("succeeded"),
-            "failed": rc_dict.get("failed"),
-            "refused": rc_dict.get("refused"),
-        }
+        expected = ['succeeded', 'failed', 'refused']
+        kwargs = {k: rc_dict[k] for k in rc_dict if (k in expected)}
         return RequestCount(**kwargs)
 
 
 class Stats(object):
+
     def __init__(self, all=None, inbound=None, outbound=None, persisted=None,
                  connections=None, channels=None, api_requests=None,
-                 token_requests=None):
+                 token_requests=None, interval_granularity=None,
+                 interval_id=None):
         self.all = all or MessageTypes()
         self.inbound = inbound or MessageTraffic()
         self.outbound = outbound or MessageTraffic()
@@ -126,6 +119,10 @@ class Stats(object):
         self.channels = channels or ResourceCount()
         self.api_requests = api_requests or RequestCount()
         self.token_requests = token_requests or RequestCount()
+        self.interval_id = interval_id or ''
+        self.interval_granularity = (interval_granularity or
+                                     granularity_from_interval_id(self.interval_id))
+        self.interval_time = interval_from_interval_id(self.interval_id)
 
     @staticmethod
     def from_dict(stats_dict):
@@ -137,9 +134,11 @@ class Stats(object):
             "outbound": MessageTraffic.from_dict(stats_dict.get("outbound")),
             "persisted": MessageTypes.from_dict(stats_dict.get("persisted")),
             "connections": ConnectionTypes.from_dict(stats_dict.get("connections")),
-            "channels": ResourceCount.from_dict(stats_dict["channels"]),
-            "api_requests": RequestCount.from_dict(stats_dict["apiRequests"]),
-            "token_requests": RequestCount.from_dict(stats_dict["tokenRequests"]),
+            "channels": ResourceCount.from_dict(stats_dict.get("channels")),
+            "api_requests": RequestCount.from_dict(stats_dict.get("apiRequests")),
+            "token_requests": RequestCount.from_dict(stats_dict.get("tokenRequests")),
+            "interval_granularity": stats_dict.get("unit"),
+            "interval_id": stats_dict.get("intervalId")
         }
 
         return Stats(**kwargs)
@@ -148,8 +147,40 @@ class Stats(object):
     def from_array(stats_array):
         return [Stats.from_dict(d) for d in stats_array]
 
+    @staticmethod
+    def to_interval_id(date_time, granularity):
+        return date_time.strftime(INTERVALS_FMT[granularity])
 
-def stats_response_processor(response):
-    stats_array = response.json()
 
-    return Stats.from_array(stats_array)
+def make_stats_response_processor(binary):
+    def stats_response_processor(response):
+        if binary:
+            stats_array = msgpack.unpackb(response.content, encoding='utf-8')
+        else:
+            stats_array = response.json()
+
+        return Stats.from_array(stats_array)
+    return stats_response_processor
+
+
+INTERVALS_FMT = {
+    'minute': '%Y-%m-%d:%H:%M',
+    'hour': '%Y-%m-%d:%H',
+    'day': '%Y-%m-%d',
+    'month': '%Y-%m',
+}
+
+
+def granularity_from_interval_id(interval_id):
+    for key, value in INTERVALS_FMT.items():
+        try:
+            datetime.strptime(interval_id, value)
+            return key
+        except ValueError:
+            pass
+    raise ValueError("Unsuported intervalId")
+
+
+def interval_from_interval_id(interval_id):
+    granularity = granularity_from_interval_id(interval_id)
+    return datetime.strptime(interval_id, INTERVALS_FMT[granularity])

--- a/ably/util/exceptions.py
+++ b/ably/util/exceptions.py
@@ -19,6 +19,9 @@ class AblyException(Exception, UnicodeMixin):
     def __unicode__(self):
         return six.u('%s %s %s') % (self.code, self.status_code, self.message)
 
+    def __str__(self):
+        return self.__unicode__()
+
     @property
     def is_server_error(self):
         return 500 <= self.status_code <= 599

--- a/test/ably/encoders_test.py
+++ b/test/ably/encoders_test.py
@@ -3,7 +3,6 @@
 import base64
 import json
 import logging
-import unittest
 
 import six
 import mock
@@ -15,12 +14,13 @@ from ably.util.crypto import get_cipher, get_default_params
 from ably.types.message import Message
 
 from test.ably.restsetup import RestSetup
+from test.ably.utils import BaseTestCase
 
 test_vars = RestSetup.get_test_vars()
 log = logging.getLogger(__name__)
 
 
-class TestTextEncodersNoEncryption(unittest.TestCase):
+class TestTextEncodersNoEncryption(BaseTestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
@@ -148,7 +148,7 @@ class TestTextEncodersNoEncryption(unittest.TestCase):
         self.assertEqual(decoded_data['encoding'], 'foo/bar')
 
 
-class TestTextEncodersEncryption(unittest.TestCase):
+class TestTextEncodersEncryption(BaseTestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
@@ -278,7 +278,7 @@ class TestTextEncodersEncryption(unittest.TestCase):
         self.assertFalse(message.encoding)
 
 
-class TestBinaryEncodersNoEncryption(unittest.TestCase):
+class TestBinaryEncodersNoEncryption(BaseTestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
@@ -368,7 +368,7 @@ class TestBinaryEncodersNoEncryption(unittest.TestCase):
         self.assertFalse(message.encoding)
 
 
-class TestBinaryEncodersEncryption(unittest.TestCase):
+class TestBinaryEncodersEncryption(BaseTestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],

--- a/test/ably/restappstats_test.py
+++ b/test/ably/restappstats_test.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from datetime import datetime
 from datetime import timedelta
 import logging
-import unittest
 
 import six
 
@@ -14,7 +13,7 @@ from ably.util.exceptions import AblyException
 from ably.http.paginatedresult import PaginatedResult
 
 from test.ably.restsetup import RestSetup
-from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol
+from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, BaseTestCase
 
 log = logging.getLogger(__name__)
 test_vars = RestSetup.get_test_vars()
@@ -99,7 +98,7 @@ class TestRestAppStatsSetup(object):
 
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)
-class TestDirectionForwards(TestRestAppStatsSetup, unittest.TestCase):
+class TestDirectionForwards(TestRestAppStatsSetup, BaseTestCase):
 
     @classmethod
     def get_params(cls):
@@ -121,7 +120,7 @@ class TestDirectionForwards(TestRestAppStatsSetup, unittest.TestCase):
 
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)
-class TestDirectionBackwards(TestRestAppStatsSetup, unittest.TestCase):
+class TestDirectionBackwards(TestRestAppStatsSetup, BaseTestCase):
 
     @classmethod
     def get_params(cls):
@@ -142,7 +141,7 @@ class TestDirectionBackwards(TestRestAppStatsSetup, unittest.TestCase):
 
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)
-class TestOnlyLastYear(TestRestAppStatsSetup, unittest.TestCase):
+class TestOnlyLastYear(TestRestAppStatsSetup, BaseTestCase):
 
     @classmethod
     def get_params(cls):
@@ -158,7 +157,7 @@ class TestOnlyLastYear(TestRestAppStatsSetup, unittest.TestCase):
 
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)
-class TestPreviousYear(TestRestAppStatsSetup, unittest.TestCase):
+class TestPreviousYear(TestRestAppStatsSetup, BaseTestCase):
 
     @classmethod
     def get_params(cls):
@@ -174,7 +173,7 @@ class TestPreviousYear(TestRestAppStatsSetup, unittest.TestCase):
 
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)
-class TestRestAppStats(TestRestAppStatsSetup, unittest.TestCase):
+class TestRestAppStats(TestRestAppStatsSetup, BaseTestCase):
 
     @dont_vary_protocol
     def test_protocols(self):

--- a/test/ably/restappstats_test.py
+++ b/test/ably/restappstats_test.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import
 
-import json
+
 from datetime import datetime
 from datetime import timedelta
 import logging
-import time
 import unittest
 
 
@@ -89,7 +88,7 @@ class TestRestAppStatsSetup(object):
                 }
             )
 
-        cls.ably.http.post('/stats', body=json.dumps(stats + previous_stats))
+        cls.ably.http.post('/stats', native_data=stats + previous_stats)
 
         cls.stats_pages = cls.ably.stats(**cls.get_params())
 

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import logging
-import unittest
 
 from ably import AblyRest
 from ably import Auth
@@ -9,6 +8,7 @@ from ably import Options
 
 
 from test.ably.restsetup import RestSetup
+from test.ably.utils import BaseTestCase
 
 test_vars = RestSetup.get_test_vars()
 
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 
 # does not make any request, no need to vary by protocol
-class TestAuth(unittest.TestCase):
+class TestAuth(BaseTestCase):
 
     def test_auth_init_key_only(self):
         ably = AblyRest(key=test_vars["keys"][0]["key_str"])

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -16,6 +16,7 @@ test_vars = RestSetup.get_test_vars()
 log = logging.getLogger(__name__)
 
 
+# does not make any request, no need to vary by protocol
 class TestAuth(unittest.TestCase):
 
     def test_auth_init_key_only(self):

--- a/test/ably/restcapability_test.py
+++ b/test/ably/restcapability_test.py
@@ -4,7 +4,6 @@ import math
 from datetime import datetime
 from datetime import timedelta
 import json
-import unittest
 
 import six
 
@@ -14,13 +13,13 @@ from ably.types.capability import Capability
 from ably.util.exceptions import AblyException
 
 from test.ably.restsetup import RestSetup
-from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol
+from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, BaseTestCase
 
 test_vars = RestSetup.get_test_vars()
 
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)
-class TestRestCapability(unittest.TestCase):
+class TestRestCapability(BaseTestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],

--- a/test/ably/restcapability_test.py
+++ b/test/ably/restcapability_test.py
@@ -14,10 +14,12 @@ from ably.types.capability import Capability
 from ably.util.exceptions import AblyException
 
 from test.ably.restsetup import RestSetup
+from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol
 
 test_vars = RestSetup.get_test_vars()
 
 
+@six.add_metaclass(VaryByProtocolTestsMetaclass)
 class TestRestCapability(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -27,9 +29,8 @@ class TestRestCapability(unittest.TestCase):
                             tls_port=test_vars["tls_port"],
                             tls=test_vars["tls"])
 
-    @property
-    def ably(self):
-        return self.__class__.ably
+    def per_protocol_setup(self, use_binary_protocol):
+        self.ably.options.use_binary_protocol = use_binary_protocol
 
     def test_blanket_intersection_with_key(self):
         key = test_vars['keys'][1]
@@ -57,6 +58,7 @@ class TestRestCapability(unittest.TestCase):
         self.assertEqual(expected_capability, token_details.capability,
                          msg="Unexpected capability")
 
+    @dont_vary_protocol
     def test_empty_ops_intersection(self):
         key = test_vars['keys'][1]
 
@@ -71,6 +73,7 @@ class TestRestCapability(unittest.TestCase):
                 key_secret=key['key_secret'],
                 token_params=token_params)
 
+    @dont_vary_protocol
     def test_empty_paths_intersection(self):
         key = test_vars['keys'][1]
 
@@ -248,6 +251,7 @@ class TestRestCapability(unittest.TestCase):
         self.assertEqual(expected_capability, token_details.capability,
                          msg="Unexpected capability")
 
+    @dont_vary_protocol
     def test_invalid_capabilities(self):
         kwargs = {
             "token_params": {
@@ -264,6 +268,7 @@ class TestRestCapability(unittest.TestCase):
         self.assertEqual(400, the_exception.status_code)
         self.assertEqual(40000, the_exception.code)
 
+    @dont_vary_protocol
     def test_invalid_capabilities_2(self):
         kwargs = {
             "token_params": {
@@ -280,7 +285,7 @@ class TestRestCapability(unittest.TestCase):
         self.assertEqual(400, the_exception.status_code)
         self.assertEqual(40000, the_exception.code)
 
-
+    @dont_vary_protocol   
     def test_invalid_capabilities_3(self):
         capability = Capability({
             "channel0": []

--- a/test/ably/restchannelhistory_test.py
+++ b/test/ably/restchannelhistory_test.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import logging
 import time
-import unittest
 
 import responses
 import six
@@ -14,14 +13,14 @@ from ably import AblyRest
 from ably.http.paginatedresult import PaginatedResult
 
 from test.ably.restsetup import RestSetup
-from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol
+from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, BaseTestCase
 
 test_vars = RestSetup.get_test_vars()
 log = logging.getLogger(__name__)
 
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)
-class TestRestChannelHistory(unittest.TestCase):
+class TestRestChannelHistory(BaseTestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
@@ -36,9 +35,9 @@ class TestRestChannelHistory(unittest.TestCase):
         self.use_binary_protocol = use_binary_protocol
 
     def test_channel_history_types(self):
-        channel_name = 'persisted:channelhistory_types'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        history0 = self.ably.channels[channel_name]
+        history0 = self.ably.channels[
+            self.protocol_channel_name('persisted:channelhistory_types')]
+
         history0.publish('history0', six.u('This is a string message payload'))
         history0.publish('history1', b'This is a byte[] message payload')
         history0.publish('history2', {'test': 'This is a JSONObject message payload'})
@@ -75,9 +74,8 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg="Expect messages in reverse order")
 
     def test_channel_history_multi_50_forwards(self):
-        channel_name = 'persisted:channelhistory_multi_50_f'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        history0 = self.ably.channels[channel_name]
+        history0 = self.ably.channels[
+            self.protocol_channel_name('persisted:channelhistory_multi_50_f')]
 
         for i in range(50):
             history0.publish('history%d' % i, str(i))
@@ -94,9 +92,8 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg='Expect messages in forward order')
 
     def test_channel_history_multi_50_backwards(self):
-        channel_name = 'persisted:channelhistory_multi_50_b'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        history0 = self.ably.channels[channel_name]
+        history0 = self.ably.channels[
+            self.protocol_channel_name('persisted:channelhistory_multi_50_b')]
 
         for i in range(50):
             history0.publish('history%d' % i, str(i))
@@ -133,7 +130,7 @@ class TestRestChannelHistory(unittest.TestCase):
         self.per_protocol_setup(True)
         channel = self.ably.channels['persisted:channelhistory_limit']
         url = self.history_mock_url('persisted:channelhistory_limit')
-        responses.add(responses.GET, url, body=msgpack.packb({}))
+        self.responses_add_empty_msg_pack(url)
         channel.history()
         self.assertNotIn('limit=', responses.calls[0].request.url.split('?')[-1])
 
@@ -143,7 +140,7 @@ class TestRestChannelHistory(unittest.TestCase):
         self.per_protocol_setup(True)
         channel = self.ably.channels['persisted:channelhistory_limit']
         url = self.history_mock_url('persisted:channelhistory_limit')
-        responses.add(responses.GET, url, body=msgpack.packb({}))
+        self.responses_add_empty_msg_pack(url)
         channel.history(limit=500)
         self.assertIn('limit=500', responses.calls[0].request.url.split('?')[-1])
         channel.history(limit=1000)
@@ -156,9 +153,8 @@ class TestRestChannelHistory(unittest.TestCase):
             channel.history(limit=1001)
 
     def test_channel_history_limit_forwards(self):
-        channel_name = 'persisted:channelhistory_limit_f'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        history0 = self.ably.channels[channel_name]
+        history0 = self.ably.channels[
+            self.protocol_channel_name('persisted:channelhistory_limit_f')]
 
         for i in range(50):
             history0.publish('history%d' % i, str(i))
@@ -176,9 +172,8 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg='Expect messages in forward order')
 
     def test_channel_history_limit_backwards(self):
-        channel_name = 'persisted:channelhistory_limit_b'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        history0 = self.ably.channels[channel_name]
+        history0 = self.ably.channels[
+            self.protocol_channel_name('persisted:channelhistory_limit_b')]
 
         for i in range(50):
             history0.publish('history%d' % i, str(i))
@@ -196,9 +191,8 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg='Expect messages in forward order')
 
     def test_channel_history_time_forwards(self):
-        channel_name = 'persisted:channelhistory_time_f'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        history0 = self.ably.channels[channel_name]
+        history0 = self.ably.channels[
+            self.protocol_channel_name('persisted:channelhistory_time_f')]
 
         for i in range(20):
             history0.publish('history%d' % i, str(i))
@@ -226,9 +220,8 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg='Expect messages in forward order')
 
     def test_channel_history_time_backwards(self):
-        channel_name = 'persisted:channelhistory_time_b'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        history0 = self.ably.channels[channel_name]
+        history0 = self.ably.channels[
+            self.protocol_channel_name('persisted:channelhistory_time_b')]
 
         for i in range(20):
             history0.publish('history%d' % i, str(i))
@@ -256,9 +249,8 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg='Expect messages in reverse order')
 
     def test_channel_history_paginate_forwards(self):
-        channel_name = 'persisted:channelhistory_paginate_f'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        history0 = self.ably.channels[channel_name]
+        history0 = self.ably.channels[
+            self.protocol_channel_name('persisted:channelhistory_paginate_f')]
 
         for i in range(50):
             history0.publish('history%d' % i, str(i))
@@ -297,9 +289,8 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg='Expected 10 messages')
         
     def test_channel_history_paginate_backwards(self):
-        channel_name = 'persisted:channelhistory_paginate_b'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        history0 = self.ably.channels[channel_name]
+        history0 = self.ably.channels[
+            self.protocol_channel_name('persisted:channelhistory_paginate_b')]
 
         for i in range(50):
             history0.publish('history%d' % i, str(i))
@@ -338,9 +329,8 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg='Expected 10 messages')
         
     def test_channel_history_paginate_forwards_first(self):
-        channel_name = 'persisted:channelhistory_paginate_first_f'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        history0 = self.ably.channels[channel_name]
+        history0 = self.ably.channels[
+            self.protocol_channel_name('persisted:channelhistory_paginate_first_f')]
 
         for i in range(50):
             history0.publish('history%d' % i, str(i))
@@ -379,9 +369,8 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg='Expected 10 messages')
         
     def test_channel_history_paginate_backwards_rel_first(self):
-        channel_name = 'persisted:channelhistory_paginate_first_b'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        history0 = self.ably.channels[channel_name]
+        history0 = self.ably.channels[
+            self.protocol_channel_name('persisted:channelhistory_paginate_first_b')]
 
         for i in range(50):
             history0.publish('history%d' % i, str(i))

--- a/test/ably/restchannelhistory_test.py
+++ b/test/ably/restchannelhistory_test.py
@@ -14,11 +14,13 @@ from ably import AblyRest
 from ably.http.paginatedresult import PaginatedResult
 
 from test.ably.restsetup import RestSetup
+from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol
 
 test_vars = RestSetup.get_test_vars()
 log = logging.getLogger(__name__)
 
 
+@six.add_metaclass(VaryByProtocolTestsMetaclass)
 class TestRestChannelHistory(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -29,12 +31,14 @@ class TestRestChannelHistory(unittest.TestCase):
                             tls=test_vars["tls"])
         cls.time_offset = cls.ably.time() - int(time.time())
 
-    @property
-    def ably(self):
-        return TestRestChannelHistory.ably
+    def per_protocol_setup(self, use_binary_protocol):
+        self.ably.options.use_binary_protocol = use_binary_protocol
+        self.use_binary_protocol = use_binary_protocol
 
     def test_channel_history_types(self):
-        history0 = TestRestChannelHistory.ably.channels['persisted:channelhistory_types']
+        channel_name = 'persisted:channelhistory_types'
+        channel_name += '_bin' if self.use_binary_protocol else '_text'
+        history0 = self.ably.channels[channel_name]
         history0.publish('history0', six.u('This is a string message payload'))
         history0.publish('history1', b'This is a byte[] message payload')
         history0.publish('history2', {'test': 'This is a JSONObject message payload'})
@@ -71,7 +75,9 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg="Expect messages in reverse order")
 
     def test_channel_history_multi_50_forwards(self):
-        history0 = TestRestChannelHistory.ably.channels['persisted:channelhistory_multi_50_f']
+        channel_name = 'persisted:channelhistory_multi_50_f'
+        channel_name += '_bin' if self.use_binary_protocol else '_text'
+        history0 = self.ably.channels[channel_name]
 
         for i in range(50):
             history0.publish('history%d' % i, str(i))
@@ -88,7 +94,9 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg='Expect messages in forward order')
 
     def test_channel_history_multi_50_backwards(self):
-        history0 = TestRestChannelHistory.ably.channels['persisted:channelhistory_multi_50_b']
+        channel_name = 'persisted:channelhistory_multi_50_b'
+        channel_name += '_bin' if self.use_binary_protocol else '_text'
+        history0 = self.ably.channels[channel_name]
 
         for i in range(50):
             history0.publish('history%d' % i, str(i))
@@ -120,16 +128,20 @@ class TestRestChannelHistory(unittest.TestCase):
         return url.format(**kwargs)
 
     @responses.activate
+    @dont_vary_protocol
     def test_channel_history_default_limit(self):
-        channel = TestRestChannelHistory.ably.channels['persisted:channelhistory_limit']
+        self.per_protocol_setup(True)
+        channel = self.ably.channels['persisted:channelhistory_limit']
         url = self.history_mock_url('persisted:channelhistory_limit')
         responses.add(responses.GET, url, body=msgpack.packb({}))
         channel.history()
         self.assertNotIn('limit=', responses.calls[0].request.url.split('?')[-1])
 
     @responses.activate
+    @dont_vary_protocol
     def test_channel_history_with_limits(self):
-        channel = TestRestChannelHistory.ably.channels['persisted:channelhistory_limit']
+        self.per_protocol_setup(True)
+        channel = self.ably.channels['persisted:channelhistory_limit']
         url = self.history_mock_url('persisted:channelhistory_limit')
         responses.add(responses.GET, url, body=msgpack.packb({}))
         channel.history(limit=500)
@@ -137,13 +149,16 @@ class TestRestChannelHistory(unittest.TestCase):
         channel.history(limit=1000)
         self.assertIn('limit=1000', responses.calls[1].request.url.split('?')[-1])
 
+    @dont_vary_protocol
     def test_channel_history_max_limit_is_1000(self):
-        channel = TestRestChannelHistory.ably.channels['persisted:channelhistory_limit']
+        channel = self.ably.channels['persisted:channelhistory_limit']
         with self.assertRaises(AblyException):
             channel.history(limit=1001)
 
     def test_channel_history_limit_forwards(self):
-        history0 = TestRestChannelHistory.ably.channels['persisted:channelhistory_limit_f']
+        channel_name = 'persisted:channelhistory_limit_f'
+        channel_name += '_bin' if self.use_binary_protocol else '_text'
+        history0 = self.ably.channels[channel_name]
 
         for i in range(50):
             history0.publish('history%d' % i, str(i))
@@ -161,7 +176,9 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg='Expect messages in forward order')
 
     def test_channel_history_limit_backwards(self):
-        history0 = TestRestChannelHistory.ably.channels['persisted:channelhistory_limit_f']
+        channel_name = 'persisted:channelhistory_limit_b'
+        channel_name += '_bin' if self.use_binary_protocol else '_text'
+        history0 = self.ably.channels[channel_name]
 
         for i in range(50):
             history0.publish('history%d' % i, str(i))
@@ -179,17 +196,19 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg='Expect messages in forward order')
 
     def test_channel_history_time_forwards(self):
-        history0 = TestRestChannelHistory.ably.channels['persisted:channelhistory_time_f']
+        channel_name = 'persisted:channelhistory_time_f'
+        channel_name += '_bin' if self.use_binary_protocol else '_text'
+        history0 = self.ably.channels[channel_name]
 
         for i in range(20):
             history0.publish('history%d' % i, str(i))
 
-        interval_start = TestRestChannelHistory.ably.time()
+        interval_start = self.ably.time()
 
         for i in range(20, 40):
             history0.publish('history%d' % i, str(i))
 
-        interval_end = TestRestChannelHistory.ably.time()
+        interval_end = self.ably.time()
 
         for i in range(40, 60):
             history0.publish('history%d' % i, str(i))
@@ -207,17 +226,19 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg='Expect messages in forward order')
 
     def test_channel_history_time_backwards(self):
-        history0 = TestRestChannelHistory.ably.channels['persisted:channelhistory_time_b']
+        channel_name = 'persisted:channelhistory_time_b'
+        channel_name += '_bin' if self.use_binary_protocol else '_text'
+        history0 = self.ably.channels[channel_name]
 
         for i in range(20):
             history0.publish('history%d' % i, str(i))
 
-        interval_start = TestRestChannelHistory.ably.time()
+        interval_start = self.ably.time()
 
         for i in range(20, 40):
             history0.publish('history%d' % i, str(i))
 
-        interval_end = TestRestChannelHistory.ably.time()
+        interval_end = self.ably.time()
 
         for i in range(40, 60):
             history0.publish('history%d' % i, str(i))
@@ -235,7 +256,9 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg='Expect messages in reverse order')
 
     def test_channel_history_paginate_forwards(self):
-        history0 = TestRestChannelHistory.ably.channels['persisted:channelhistory_paginate_f']
+        channel_name = 'persisted:channelhistory_paginate_f'
+        channel_name += '_bin' if self.use_binary_protocol else '_text'
+        history0 = self.ably.channels[channel_name]
 
         for i in range(50):
             history0.publish('history%d' % i, str(i))
@@ -274,7 +297,9 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg='Expected 10 messages')
         
     def test_channel_history_paginate_backwards(self):
-        history0 = TestRestChannelHistory.ably.channels['persisted:channelhistory_paginate_b']
+        channel_name = 'persisted:channelhistory_paginate_b'
+        channel_name += '_bin' if self.use_binary_protocol else '_text'
+        history0 = self.ably.channels[channel_name]
 
         for i in range(50):
             history0.publish('history%d' % i, str(i))
@@ -313,7 +338,9 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg='Expected 10 messages')
         
     def test_channel_history_paginate_forwards_first(self):
-        history0 = TestRestChannelHistory.ably.channels['persisted:channelhistory_paginate_first_f']
+        channel_name = 'persisted:channelhistory_paginate_first_f'
+        channel_name += '_bin' if self.use_binary_protocol else '_text'
+        history0 = self.ably.channels[channel_name]
 
         for i in range(50):
             history0.publish('history%d' % i, str(i))
@@ -352,7 +379,9 @@ class TestRestChannelHistory(unittest.TestCase):
                 msg='Expected 10 messages')
         
     def test_channel_history_paginate_backwards_rel_first(self):
-        history0 = TestRestChannelHistory.ably.channels['persisted:channelhistory_paginate_first_b']
+        channel_name = 'persisted:channelhistory_paginate_first_b'
+        channel_name += '_bin' if self.use_binary_protocol else '_text'
+        history0 = self.ably.channels[channel_name]
 
         for i in range(50):
             history0.publish('history%d' % i, str(i))

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import json
 import logging
-import unittest
 
 import six
 from six.moves import range
@@ -14,14 +13,14 @@ from ably import AblyRest
 from ably.types.message import Message
 
 from test.ably.restsetup import RestSetup
-from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol
+from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, BaseTestCase
 
 test_vars = RestSetup.get_test_vars()
 log = logging.getLogger(__name__)
 
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)
-class TestRestChannelPublish(unittest.TestCase):
+class TestRestChannelPublish(BaseTestCase):
     def setUp(self):
         self.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
                              host=test_vars["host"],
@@ -34,9 +33,8 @@ class TestRestChannelPublish(unittest.TestCase):
         self.use_binary_protocol = use_binary_protocol
 
     def test_publish_various_datatypes_text(self):
-        channel_name = 'persisted:publish0'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        publish0 = self.ably.channels[channel_name]
+        publish0 = self.ably.channels[
+            self.protocol_channel_name('persisted:publish0')]
 
         publish0.publish("publish0", six.u("This is a string message payload"))
         publish0.publish("publish1", b"This is a byte[] message payload")
@@ -73,9 +71,8 @@ class TestRestChannelPublish(unittest.TestCase):
             self.assertRaises(AblyException, channel.publish, 'event', data)
 
     def test_publish_message_list(self):
-        channel_name = 'persisted:message_list_channel'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        channel = self.ably.channels[channel_name]
+        channel = self.ably.channels[
+            self.protocol_channel_name('persisted:message_list_channel')]
 
         expected_messages = [Message("name-{}".format(i), str(i)) for i in range(3)]
 
@@ -93,9 +90,8 @@ class TestRestChannelPublish(unittest.TestCase):
             self.assertEqual(m.data, expected_m.data)
 
     def test_message_list_generate_one_request(self):
-        channel_name = 'persisted:message_list_channel_one_request'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        channel = self.ably.channels[channel_name]
+        channel = self.ably.channels[
+            self.protocol_channel_name('persisted:message_list_channel_one_request')]
 
         expected_messages = [Message("name-{}".format(i), six.text_type(i)) for i in range(3)]
 
@@ -135,9 +131,8 @@ class TestRestChannelPublish(unittest.TestCase):
         self.assertEqual(40160, cm.exception.code)
 
     def test_publish_message_null_name(self):
-        channel_name = 'persisted:message_null_name_channel'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        channel = self.ably.channels[channel_name]
+        channel = self.ably.channels[
+            self.protocol_channel_name('persisted:message_null_name_channel')]
 
         data = "String message"
         channel.publish(name=None, data=data)
@@ -153,9 +148,8 @@ class TestRestChannelPublish(unittest.TestCase):
         self.assertEqual(messages[0].data, data)
 
     def test_publish_message_null_data(self):
-        channel_name = 'persisted:message_null_data_channel'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        channel = self.ably.channels[channel_name]
+        channel = self.ably.channels[
+            self.protocol_channel_name('persisted:message_null_data_channel')]
 
         name = "Test name"
         channel.publish(name=name, data=None)
@@ -171,9 +165,8 @@ class TestRestChannelPublish(unittest.TestCase):
         self.assertIsNone(messages[0].data)
 
     def test_publish_message_null_name_and_data(self):
-        channel_name = 'persisted:null_name_and_data_channel'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        channel = self.ably.channels[channel_name]
+        channel = self.ably.channels[
+            self.protocol_channel_name('persisted:null_name_and_data_channel')]
 
         channel.publish(name=None, data=None)
         channel.publish()
@@ -190,9 +183,8 @@ class TestRestChannelPublish(unittest.TestCase):
             self.assertIsNone(m.data)
 
     def test_publish_message_null_name_and_data_keys_arent_sent(self):
-        channel_name = 'persisted:null_name_and_data_keys_arent_sent_channel'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
-        channel = self.ably.channels[channel_name]
+        channel = self.ably.channels[
+            self.protocol_channel_name('persisted:null_name_and_data_keys_arent_sent_channel')]
 
         with mock.patch('ably.rest.rest.Http.post',
                         wraps=channel.ably.http.post) as post_mock:
@@ -216,10 +208,9 @@ class TestRestChannelPublish(unittest.TestCase):
             self.assertNotIn('data', posted_body)
 
     def test_message_attr(self):
-        channel_name = 'persisted:publish_message_attr'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
+        publish0 = self.ably.channels[
+            self.protocol_channel_name('persisted:publish_message_attr')]
 
-        publish0 = self.ably.channels[channel_name]
         messages = [Message('publish',
                             {"test": "This is a JSONObject message payload"},
                             client_id='client_id')]

--- a/test/ably/restchannels_test.py
+++ b/test/ably/restchannels_test.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import collections
-import unittest
 
 from six.moves import range
 
@@ -12,12 +11,13 @@ from ably.types.capability import Capability
 from ably.util.crypto import get_default_params
 
 from test.ably.restsetup import RestSetup
+from test.ably.utils import BaseTestCase
 
 test_vars = RestSetup.get_test_vars()
 
 
 # makes no request, no need to use different protocols
-class TestChannels(unittest.TestCase):
+class TestChannels(BaseTestCase):
 
     def setUp(self):
         self.ably = AblyRest(key=test_vars["keys"][0]["key_str"],

--- a/test/ably/restchannels_test.py
+++ b/test/ably/restchannels_test.py
@@ -16,6 +16,7 @@ from test.ably.restsetup import RestSetup
 test_vars = RestSetup.get_test_vars()
 
 
+# makes no request, no need to use different protocols
 class TestChannels(unittest.TestCase):
 
     def setUp(self):

--- a/test/ably/restcrypto_test.py
+++ b/test/ably/restcrypto_test.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import json
 import os
 import logging
-import unittest
 import base64
 
 import six
@@ -17,14 +16,14 @@ from ably.util.crypto import CipherParams, get_cipher, get_default_params
 from Crypto import Random
 
 from test.ably.restsetup import RestSetup
-from test.ably.utils import dont_vary_protocol, VaryByProtocolTestsMetaclass
+from test.ably.utils import dont_vary_protocol, VaryByProtocolTestsMetaclass, BaseTestCase
 
 test_vars = RestSetup.get_test_vars()
 log = logging.getLogger(__name__)
 
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)
-class TestRestCrypto(unittest.TestCase):
+class TestRestCrypto(BaseTestCase):
 
     def setUp(self):
         options = {
@@ -72,8 +71,7 @@ class TestRestCrypto(unittest.TestCase):
         self.assertEqual(expected_ciphertext, actual_ciphertext)
 
     def test_crypto_publish(self):
-        channel_name = 'persisted:crypto_publish_text'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
+        channel_name = self.protocol_channel_name('persisted:crypto_publish_text')
         channel_options = ChannelOptions(encrypted=True,
                                          cipher_params=get_default_params())
         publish0 = self.ably.channels.get(channel_name, channel_options)
@@ -142,8 +140,8 @@ class TestRestCrypto(unittest.TestCase):
                 msg="Expect publish6 to be expected JSONObject")
 
     def test_crypto_publish_key_mismatch(self):
-        channel_name = 'persisted:crypto_publish_key_mismatch'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
+        channel_name = self.protocol_channel_name('persisted:crypto_publish_key_mismatch')
+
         channel_options = ChannelOptions(encrypted=True,
                                          cipher_params=get_default_params())
         publish0 = self.ably.channels.get(channel_name, channel_options)
@@ -170,8 +168,7 @@ class TestRestCrypto(unittest.TestCase):
         self.assertEqual('invalid-padding', the_exception.message)
 
     def test_crypto_send_unencrypted(self):
-        channel_name = 'persisted:crypto_send_unencrypted'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
+        channel_name = self.protocol_channel_name('persisted:crypto_send_unencrypted')
         publish0 = self.ably.channels[channel_name]
 
         publish0.publish("publish3", six.u("This is a string message payload"))
@@ -205,8 +202,7 @@ class TestRestCrypto(unittest.TestCase):
                 msg="Expect publish6 to be expected JSONObject")
 
     def test_crypto_encrypted_unhandled(self):
-        channel_name = 'persisted:crypto_send_encrypted_unhandled'
-        channel_name += '_bin' if self.use_binary_protocol else '_text'
+        channel_name = self.protocol_channel_name('persisted:crypto_send_encrypted_unhandled')
         key = '0123456789abcdef'
         data = six.u('foobar')
         channel_options = ChannelOptions(encrypted=True,
@@ -280,9 +276,9 @@ class AbstractTestCryptoWithFixture(object):
             self.assertEqual(as_dict['encoding'], expected['encoding'])
 
 
-class TestCryptoWithFixture128(AbstractTestCryptoWithFixture, unittest.TestCase):
+class TestCryptoWithFixture128(AbstractTestCryptoWithFixture, BaseTestCase):
     fixture_file = 'crypto-data-128.json'
 
 
-class TestCryptoWithFixture256(AbstractTestCryptoWithFixture, unittest.TestCase):
+class TestCryptoWithFixture256(AbstractTestCryptoWithFixture, BaseTestCase):
     fixture_file = 'crypto-data-256.json'

--- a/test/ably/resthttp_test.py
+++ b/test/ably/resthttp_test.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import unittest
 import time
 
 import mock
@@ -11,9 +10,10 @@ from ably import AblyRest
 from ably.transport.defaults import Defaults
 from ably.types.options import Options
 from ably.util.exceptions import AblyException
+from test.ably.utils import BaseTestCase
 
 
-class TestRestHttp(unittest.TestCase):
+class TestRestHttp(BaseTestCase):
     def test_max_retry_attempts_and_timeouts(self):
         ably = AblyRest(token="foo")
         self.assertIn('single_request_connect_timeout', ably.http.CONNECTION_RETRY)

--- a/test/ably/restinit_test.py
+++ b/test/ably/restinit_test.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import unittest
 
+import six
 from mock import patch
 
 from ably import AblyRest
@@ -9,11 +10,14 @@ from ably import AblyException
 from ably.transport.defaults import Defaults
 
 from test.ably.restsetup import RestSetup
+from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol
 
 test_vars = RestSetup.get_test_vars()
 
 
+@six.add_metaclass(VaryByProtocolTestsMetaclass)
 class TestRestInit(unittest.TestCase):
+    @dont_vary_protocol
     def test_key_only(self):
         ably = AblyRest(key=test_vars["keys"][0]["key_str"])
         self.assertEqual(ably.options.key_name, test_vars["keys"][0]["key_name"],
@@ -21,16 +25,21 @@ class TestRestInit(unittest.TestCase):
         self.assertEqual(ably.options.key_secret, test_vars["keys"][0]["key_secret"],
                          "Key secret does not match")
 
+    def per_protocol_setup(self, use_binary_protocol):
+        self.use_binary_protocol = use_binary_protocol
+
+    @dont_vary_protocol
     def test_with_token(self):
         ably = AblyRest(token="foo")
         self.assertEqual(ably.options.auth_token, "foo",
                          "Token not set at options")
-
+    @dont_vary_protocol
     def test_with_options_token_callback(self):
         def token_callback(**params):
             return "this_is_not_really_a_token_request"
         AblyRest(auth_callback=token_callback)
 
+    @dont_vary_protocol
     def test_ambiguous_key_raises_value_error(self):
         self.assertRaisesRegexp(ValueError, "mutually exclusive", AblyRest,
                                 key=test_vars["keys"][0]["key_str"],
@@ -39,12 +48,14 @@ class TestRestInit(unittest.TestCase):
                                 key=test_vars["keys"][0]["key_str"],
                                 key_secret='x')
 
+    @dont_vary_protocol
     def test_with_key_name_or_secret_only(self):
         self.assertRaisesRegexp(ValueError, "key is missing", AblyRest,
                                 key_name='x')
         self.assertRaisesRegexp(ValueError, "key is missing", AblyRest,
                                 key_secret='x')
 
+    @dont_vary_protocol
     def test_with_key_name_and_secret(self):
         ably = AblyRest(key_name="foo", key_secret="bar")
         self.assertEqual(ably.options.key_name, "foo",
@@ -52,20 +63,24 @@ class TestRestInit(unittest.TestCase):
         self.assertEqual(ably.options.key_secret, "bar",
                          "Key secret does not match")
 
+    @dont_vary_protocol
     def test_with_options_auth_url(self):
         AblyRest(auth_url='not_really_an_url')
 
+    @dont_vary_protocol
     def test_specified_host(self):
         ably = AblyRest(token='foo', host="some.other.host")
         self.assertEqual("some.other.host", ably.options.host,
                          msg="Unexpected host mismatch")
 
+    @dont_vary_protocol
     def test_specified_port(self):
         ably = AblyRest(token='foo', port=9998, tls_port=9999)
         self.assertEqual(9999, Defaults.get_port(ably.options),
                          msg="Unexpected port mismatch. Expected: 9999. Actual: %d" %
                          ably.options.tls_port)
 
+    @dont_vary_protocol
     def test_tls_defaults_to_true(self):
         ably = AblyRest(token='foo')
         self.assertTrue(ably.options.tls,
@@ -73,6 +88,7 @@ class TestRestInit(unittest.TestCase):
         self.assertEqual(Defaults.tls_port, Defaults.get_port(ably.options),
                          msg="Unexpected port mismatch")
 
+    @dont_vary_protocol
     def test_tls_can_be_disabled(self):
         ably = AblyRest(token='foo', tls=False)
         self.assertFalse(ably.options.tls,
@@ -80,9 +96,11 @@ class TestRestInit(unittest.TestCase):
         self.assertEqual(Defaults.port, Defaults.get_port(ably.options),
                          msg="Unexpected port mismatch")
 
+    @dont_vary_protocol
     def test_with_no_params(self):
         self.assertRaises(ValueError, AblyRest)
 
+    @dont_vary_protocol
     def test_with_no_auth_params(self):
         self.assertRaises(ValueError, AblyRest, port=111)
 
@@ -91,7 +109,8 @@ class TestRestInit(unittest.TestCase):
                         host=test_vars["host"],
                         port=test_vars["port"],
                         tls_port=test_vars["tls_port"],
-                        tls=test_vars["tls"], query_time=True)
+                        tls=test_vars["tls"], query_time=True,
+                        use_binary_protocol=self.use_binary_protocol)
 
         timestamp = ably.auth._timestamp
         with patch('ably.rest.rest.AblyRest.time', wraps=ably.time) as server_time,\
@@ -100,6 +119,7 @@ class TestRestInit(unittest.TestCase):
             self.assertFalse(local_time.called)
             self.assertTrue(server_time.called)
 
+    @dont_vary_protocol
     def test_requests_over_https_production(self):
         ably = AblyRest(token='token')
         self.assertEquals('https://rest.ably.io',
@@ -108,6 +128,7 @@ class TestRestInit(unittest.TestCase):
                             ably.http.preferred_host))
         self.assertEqual(ably.http.preferred_port, 443)
 
+    @dont_vary_protocol
     def test_requests_over_http_production(self):
         ably = AblyRest(token='token', tls=False)
         self.assertEquals('http://rest.ably.io',
@@ -116,6 +137,7 @@ class TestRestInit(unittest.TestCase):
                             ably.http.preferred_host))
         self.assertEqual(ably.http.preferred_port, 80)
 
+    @dont_vary_protocol
     def test_request_basic_auth_over_http_fails(self):
         ably = AblyRest(key_secret='foo', key_name='bar', tls=False)
 

--- a/test/ably/restinit_test.py
+++ b/test/ably/restinit_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import unittest
-
 import six
 from mock import patch
 
@@ -10,13 +8,13 @@ from ably import AblyException
 from ably.transport.defaults import Defaults
 
 from test.ably.restsetup import RestSetup
-from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol
+from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, BaseTestCase
 
 test_vars = RestSetup.get_test_vars()
 
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)
-class TestRestInit(unittest.TestCase):
+class TestRestInit(BaseTestCase):
     @dont_vary_protocol
     def test_key_only(self):
         ably = AblyRest(key=test_vars["keys"][0]["key_str"])

--- a/test/ably/restpaginatedresult_test.py
+++ b/test/ably/restpaginatedresult_test.py
@@ -29,7 +29,8 @@ class TestPaginatedResult(unittest.TestCase):
                              host=test_vars["host"],
                              port=test_vars["port"],
                              tls_port=test_vars["tls_port"],
-                             tls=test_vars["tls"])
+                             tls=test_vars["tls"],
+                             use_binary_protocol=False)
 
         # Mocked responses
         # without headers
@@ -57,11 +58,11 @@ class TestPaginatedResult(unittest.TestCase):
         self.paginated_result = PaginatedResult.paginated_query(
             self.ably.http,
             'http://rest.ably.io/channels/channel_name/ch1',
-            {}, lambda response: response.json())
+            {}, lambda response: response.to_native())
         self.paginated_result_with_headers = PaginatedResult.paginated_query(
             self.ably.http,
             'http://rest.ably.io/channels/channel_name/ch2',
-            {}, lambda response: response.json())
+            {}, lambda response: response.to_native())
 
     def tearDown(self):
         responses.stop()

--- a/test/ably/restpaginatedresult_test.py
+++ b/test/ably/restpaginatedresult_test.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import re
-import unittest
 
 import responses
 
@@ -9,11 +8,12 @@ from ably import AblyRest
 from ably.http.paginatedresult import PaginatedResult
 
 from test.ably.restsetup import RestSetup
+from test.ably.utils import BaseTestCase
 
 test_vars = RestSetup.get_test_vars()
 
 
-class TestPaginatedResult(unittest.TestCase):
+class TestPaginatedResult(BaseTestCase):
 
     def get_response_callback(self, headers, body, status):
         def callback(request):

--- a/test/ably/restpresence_test.py
+++ b/test/ably/restpresence_test.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import
 
-import unittest
 from datetime import datetime, timedelta
 
 import six
@@ -16,14 +15,14 @@ from ably.types.presence import (PresenceMessage,
 from ably import ChannelOptions
 from ably.util.crypto import get_default_params
 
-from test.ably.utils import dont_vary_protocol, VaryByProtocolTestsMetaclass
+from test.ably.utils import dont_vary_protocol, VaryByProtocolTestsMetaclass, BaseTestCase
 from test.ably.restsetup import RestSetup
 
 test_vars = RestSetup.get_test_vars()
 
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)
-class TestPresence(unittest.TestCase):
+class TestPresence(BaseTestCase):
 
     def setUp(self):
         self.ably = AblyRest(test_vars["keys"][0]["key_str"],
@@ -144,7 +143,7 @@ class TestPresence(unittest.TestCase):
     @responses.activate
     def test_get_presence_default_limit(self):
         url = self.presence_mock_url()
-        responses.add(responses.GET, url, body=msgpack.packb({}))
+        self.responses_add_empty_msg_pack(url)
         self.channel.presence.get()
         self.assertNotIn('limit=', responses.calls[0].request.url.split('?')[-1])
 
@@ -152,7 +151,7 @@ class TestPresence(unittest.TestCase):
     @responses.activate
     def test_get_presence_with_limit(self):
         url = self.presence_mock_url()
-        responses.add(responses.GET, url, body=msgpack.packb({}))
+        self.responses_add_empty_msg_pack(url)
         self.channel.presence.get(300)
         self.assertIn('limit=300', responses.calls[0].request.url.split('?')[-1])
 
@@ -160,14 +159,14 @@ class TestPresence(unittest.TestCase):
     @responses.activate
     def test_get_presence_max_limit_is_1000(self):
         url = self.presence_mock_url()
-        responses.add(responses.GET, url, body=msgpack.packb({}))
+        self.responses_add_empty_msg_pack(url)
         self.assertRaises(ValueError, self.channel.presence.get, 5000)
 
     @dont_vary_protocol
     @responses.activate
     def test_history_default_limit(self):
         url = self.history_mock_url()
-        responses.add(responses.GET, url, body=msgpack.packb({}))
+        self.responses_add_empty_msg_pack(url)
         self.channel.presence.history()
         self.assertNotIn('limit=', responses.calls[0].request.url.split('?')[-1])
 
@@ -175,7 +174,7 @@ class TestPresence(unittest.TestCase):
     @responses.activate
     def test_history_with_limit(self):
         url = self.history_mock_url()
-        responses.add(responses.GET, url, body=msgpack.packb({}))
+        self.responses_add_empty_msg_pack(url)
         self.channel.presence.history(300)
         self.assertIn('limit=300', responses.calls[0].request.url.split('?')[-1])
 
@@ -183,7 +182,7 @@ class TestPresence(unittest.TestCase):
     @responses.activate
     def test_history_with_direction(self):
         url = self.history_mock_url()
-        responses.add(responses.GET, url, body=msgpack.packb({}))
+        self.responses_add_empty_msg_pack(url)
         self.channel.presence.history(direction='backwards')
         self.assertIn('direction=backwards', responses.calls[0].request.url.split('?')[-1])
 
@@ -191,14 +190,14 @@ class TestPresence(unittest.TestCase):
     @responses.activate
     def test_history_max_limit_is_1000(self):
         url = self.history_mock_url()
-        responses.add(responses.GET, url, body=msgpack.packb({}))
+        self.responses_add_empty_msg_pack(url)
         self.assertRaises(ValueError, self.channel.presence.history, 5000)
 
     @dont_vary_protocol
     @responses.activate
     def test_with_milisecond_start_end(self):
         url = self.history_mock_url()
-        responses.add(responses.GET, url, body=msgpack.packb({}))
+        self.responses_add_empty_msg_pack(url)
         self.channel.presence.history(start=100000, end=100001)
         self.assertIn('start=100000', responses.calls[0].request.url.split('?')[-1])
         self.assertIn('end=100001', responses.calls[0].request.url.split('?')[-1])
@@ -211,7 +210,7 @@ class TestPresence(unittest.TestCase):
         start_ms = 1439658704706
         end = start + timedelta(hours=1)
         end_ms = start_ms + (1000 * 60 * 60)
-        responses.add(responses.GET, url, body=msgpack.packb({}))
+        self.responses_add_empty_msg_pack(url)
         self.channel.presence.history(start=start, end=end)
         self.assertIn('start=' + str(start_ms), responses.calls[0].request.url.split('?')[-1])
         self.assertIn('end=' + str(end_ms), responses.calls[0].request.url.split('?')[-1])
@@ -222,6 +221,6 @@ class TestPresence(unittest.TestCase):
         url = self.history_mock_url()
         end = datetime(2015, 8, 15, 17, 11, 44, 706539)
         start = end + timedelta(hours=1)
-        responses.add(responses.GET, url, body=msgpack.packb({}))
+        self.responses_add_empty_msg_pack(url)
         with self.assertRaisesRegexp(ValueError, "'end' parameter has to be greater than or equal to 'start'"):
             self.channel.presence.history(start=start, end=end)

--- a/test/ably/resttime_test.py
+++ b/test/ably/resttime_test.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import time
-import unittest
 
 import six
 
@@ -10,13 +9,13 @@ from ably import AblyRest
 from ably import Options
 
 from test.ably.restsetup import RestSetup
-from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol
+from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, BaseTestCase
 
 test_vars = RestSetup.get_test_vars()
 
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)
-class TestRestTime(unittest.TestCase):
+class TestRestTime(BaseTestCase):
 
     def per_protocol_setup(self, use_binary_protocol):
         self.use_binary_protocol = use_binary_protocol

--- a/test/ably/resttoken_test.py
+++ b/test/ably/resttoken_test.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import time
 import json
 import logging
-import unittest
 
 from mock import patch
 import six
@@ -14,14 +13,14 @@ from ably import Capability
 from ably import Options
 
 from test.ably.restsetup import RestSetup
-from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol
+from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, BaseTestCase
 
 test_vars = RestSetup.get_test_vars()
 log = logging.getLogger(__name__)
 
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)
-class TestRestToken(unittest.TestCase):
+class TestRestToken(BaseTestCase):
     def server_time(self):
         return self.ably.time()
 

--- a/test/ably/utils.py
+++ b/test/ably/utils.py
@@ -1,0 +1,72 @@
+
+import json
+from importlib import import_module
+from functools import wraps
+
+import msgpack
+import mock
+
+
+TO_MOCK = [
+    'ably.types.presence.make_presence_response_handler',
+    'ably.types.presence.make_encrypted_presence_response_handler',
+    'ably.rest.rest.make_stats_response_processor',
+]
+
+
+def assert_responses_types(types):
+    """
+    This code is a bit complicated but saves a lot of coding.
+    It is a decorator to check if we retrieved presence with the correct protocol.
+    usage:
+
+    @assert_responses_types(['json', 'msgpack'])
+    def test_something(self):
+        ...
+
+    this will check if we receive two responses, the first using json and the
+    second msgpack
+    """
+    responses = []
+
+    def _get_side_effect_that_saves_response(handler_str):
+        module = import_module('.'.join(handler_str.split('.')[:-1]))
+        old_handler = getattr(module, handler_str.split('.')[-1])
+
+        def side_effect(*args, **kwargs):
+            def handler(response):
+                responses.append(response)
+                return old_handler(*args, **kwargs)(response)
+            return handler
+        return side_effect
+
+    def patch_handlers():
+        patchers = []
+        for handler in TO_MOCK:
+            patchers.append(mock.patch(
+                            handler,
+                            _get_side_effect_that_saves_response(handler)))
+            patchers[-1].start()
+        return patchers
+
+    def unpatch_handlers(patchers):
+        for patcher in patchers:
+            patcher.stop()
+
+    def test_decorator(fn):
+        @wraps(fn)
+        def test_decorated(self, *args, **kwargs):
+            patchers = patch_handlers()
+            fn(self, *args, **kwargs)
+            unpatch_handlers(patchers)
+            self.assertEquals(len(types), len(responses))
+            for type_name, response in zip(types, responses):
+                if type_name == 'json':
+                    self.assertEquals(response.headers['content-type'], 'application/json')
+                    json.loads(response.text)
+                else:
+                    self.assertEquals(response.headers['content-type'], 'application/x-msgpack')
+                    msgpack.unpackb(response.content, encoding='utf-8')
+
+        return test_decorated
+    return test_decorator

--- a/test/ably/utils.py
+++ b/test/ably/utils.py
@@ -1,10 +1,23 @@
 
+import unittest
 import json
 from functools import wraps
-from ably.http.http import Http
 
 import msgpack
 import mock
+import responses
+
+from ably.http.http import Http
+
+
+class BaseTestCase(unittest.TestCase):
+
+    def responses_add_empty_msg_pack(self, url, method=responses.GET):
+        responses.add(responses.GET, url, body=msgpack.packb({}),
+                      content_type='application/x-msgpack')
+
+    def protocol_channel_name(self, name):
+        return name + ('_bin' if self.use_binary_protocol else '_text')
 
 
 def assert_responses_type(protocol):


### PR DESCRIPTION
* (G1) Every test should be executed using all supported protocols (i.e. JSON and MessagePack if supported). This includes both sending & receiving data.  See http://msgpack.org/ for more info on MsgPack
* (G2) All tests by default are run against a special Ably sandbox environment. This environment allows apps to be provisioned without any authentication that can then be used for client library testing...
* (G3) Testing statistics can be tricky...To create stats you must send an authenticated POST request to the stats JSON to https://sandbox-rest.ably.io/stats with the stats data you wish to create. See the Javascript stats fixture (https://goo.gl/hOMkab) and setup helper (https://goo.gl/YKyRXI) as an example.

* (RSC6) RestClient#stats function:
  * (RSC6a) Returns a PaginatedResult page containing Stats objects in thePaginatedResult#items attribute returned from the stats request
  * (RSC6b) Supports the following params:
    * (RSC6b1) start and end are timestamp fields represented as milliseconds since epoch, or where suitable to the language, Date or Time objects. start must be equal to or less than end and is unaffected by the request direction
    * (RSC6b2) direction backwards or forwards; if omitted the direction defaults to the REST API default (backwards)
    * (RSC6b3) limit supports up to 1,000 items; if omitted the limit defaults to the REST API default (100)
    * (RSC6b4) unit is the period for which the stats will be aggregated by, values supported areminute, hour, day or month; if omitted the unit defaults to the REST API default (minute)

* (TS1) Stats is a type encapsulating a statistics datapoint retrieved from the REST stats endpoint (http://goo.gl/vJTYUd). See example statistics in JSON format, http://goo.gl/hKxLuo
* (TS2) All stats values default to zero when no underlying JSON value exists. We send sparse JSON to stats requests omitting fields where the value is zero to reduce bandwidth and optimise JSON parsing.
* (TS3) See the Ruby Stats type documentation, http://goo.gl/Nv07TU
* (TS4) Stats.ConnectionTypes – see the Ruby ConnectionTypes documentation, http://goo.gl/72fQ7Z
* (TS5) Stats.MessageCount – see the Ruby MessageCount documentation, http://goo.gl/l8Hc1P
* (TS6) Stats.MessageTypes – see the Ruby MessageTypes documentation, http://goo.gl/TpIh5I
* (TS7) Stats.MessageTraffic – see the Ruby MessageTraffic documentation, http://goo.gl/8SjQAJ
* (TS8) Stats.RequestCount – see the Ruby RequestCount documentation, http://goo.gl/lFhZLC
* (TS9) Stats.ResourceCount – see the Ruby ResourceCount documentation, http://goo.gl/jfu0q1