### PR TITLE
RSA10: Auth#authorise

### DIFF
--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -5,6 +5,8 @@ import time
 import unittest
 
 import mock
+import six
+
 from ably import AblyRest
 from ably import Auth
 from ably import Options
@@ -12,7 +14,7 @@ from ably.types.tokendetails import TokenDetails
 
 
 from test.ably.restsetup import RestSetup
-from test.ably.utils import BaseTestCase
+from test.ably.utils import BaseTestCase, VaryByProtocolTestsMetaclass, dont_vary_protocol 
 
 test_vars = RestSetup.get_test_vars()
 
@@ -77,7 +79,8 @@ class TestAuth(BaseTestCase):
                 msg="Unexpected Auth method mismatch")
 
 
-class TestAuthAuthorize(unittest.TestCase):
+@six.add_metaclass(VaryByProtocolTestsMetaclass)
+class TestAuthAuthorize(BaseTestCase):
 
     def setUp(self):
         self.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
@@ -85,6 +88,9 @@ class TestAuthAuthorize(unittest.TestCase):
                              port=test_vars["port"],
                              tls_port=test_vars["tls_port"],
                              tls=test_vars["tls"])
+
+    def per_protocol_setup(self, use_binary_protocol):
+        self.ably.options.use_binary_protocol = use_binary_protocol
 
     def test_if_authorize_changes_auth_method_to_token(self):
 
@@ -133,6 +139,7 @@ class TestAuthAuthorize(unittest.TestCase):
 
         self.assertIsInstance(token, TokenDetails)
 
+    @dont_vary_protocol
     def test_authorize_adhere_to_request_token(self):
 
         token_params = {'ttl': 100}

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -132,3 +132,15 @@ class TestAuthAuthorize(unittest.TestCase):
         token = self.ably.auth.authorise()
 
         self.assertIsInstance(token, TokenDetails)
+
+    def test_authorize_adhere_to_request_token(self):
+
+        token_params = {'ttl': 100}
+        auth_params = {'auth_url': 'http://somewhere.com'}
+
+        with mock.patch('ably.rest.auth.Auth.request_token') as request_mock:
+            self.ably.auth.authorise(auth_params=auth_params,
+                                     token_params=token_params)
+
+        request_mock.assert_called_once_with(auth_params=auth_params,
+                                             token_params=token_params)


### PR DESCRIPTION
* (RSA10) Auth#authorise function:
  * (RSA10a) Instructs the library to create a token if needed and use Token Auth for all future requests
  * (RSA10b) Supports all AuthOptions and TokenParams in the function arguments
  * (RSA10c) Will not create a new token unless no previous token exists or current token has expired
  * (RSA10d) Providing the option force set to true will force authorise to issue a new token even if an existing token exists.
  * (RSA10e) Adheres to the implementation of requestToken when issuing new tokens	
  * (RSA10f) Returns a TokenDetails object that contains the token string + token meta data		