### PR TITLE
Changes to client options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,5 +77,5 @@ AblyRest(token="token.string")
 ```
 
 ```python
-AblyRest(key="api:key", host="custom.host", port=8080)
+AblyRest(key="api:key", rest_host="custom.host", port=8080)
 ```

--- a/ably/http/http.py
+++ b/ably/http/http.py
@@ -116,7 +116,7 @@ class Http(object):
     @reauth_if_expired
     def make_request(self, method, path, headers=None, body=None,
                      native_data=None, skip_auth=False, timeout=None):
-        fallback_hosts = Defaults.get_fallback_hosts(self.__options)
+        fallback_hosts = Defaults.get_fallback_rest_hosts(self.__options)
         if fallback_hosts:
             fallback_hosts.insert(0, self.preferred_host)
             fallback_hosts = itertools.cycle(fallback_hosts)
@@ -151,6 +151,8 @@ class Http(object):
         requested_at = time.time()
         for retry_count in range(max_retry_attempts):
             host = next(fallback_hosts) if fallback_hosts else self.preferred_host
+            if self.options.environment:
+                host = self.options.environment + '-' + host
 
             base_url = "%s://%s:%d" % (self.preferred_scheme,
                                        host,
@@ -208,7 +210,7 @@ class Http(object):
 
     @property
     def preferred_host(self):
-        return Defaults.get_host(self.options)
+        return Defaults.get_rest_host(self.options)
 
     @property
     def preferred_port(self):

--- a/ably/rest/auth.py
+++ b/ably/rest/auth.py
@@ -51,7 +51,9 @@ class Auth(object):
         # Using token auth
         self.__auth_method = Auth.Method.TOKEN
 
-        if options.auth_token:
+        if options.token_details:
+            self.__token_details = options.token_details
+        elif options.auth_token:
             self.__token_details = TokenDetails(token=options.auth_token)
         else:
             self.__token_details = None

--- a/ably/rest/rest.py
+++ b/ably/rest/rest.py
@@ -12,13 +12,14 @@ from ably.rest.channel import Channels
 from ably.util.exceptions import AblyException, catch_all
 from ably.types.options import Options
 from ably.types.stats import make_stats_response_processor
+from ably.types.tokendetails import TokenDetails
 
 log = logging.getLogger(__name__)
 
 
 class AblyRest(object):
     """Ably Rest Client"""
-    def __init__(self, key=None, token=None, **kwargs):
+    def __init__(self, key=None, token=None, token_details=None, **kwargs):
         """Create an AblyRest instance.
 
         :Parameters:
@@ -27,6 +28,7 @@ class AblyRest(object):
 
           **Or**
           - `token`: a valid token string
+          - `token_details`: an instance of TokenDetails class
 
           **Optional Parameters**
           - `client_id`: Undocumented
@@ -47,6 +49,10 @@ class AblyRest(object):
             options = Options(key=key, **kwargs)
         elif token is not None:
             options = Options(auth_token=token, **kwargs)
+        elif token_details is not None:
+            if not isinstance(token_details, TokenDetails):
+                raise ValueError("token_details must be an instance of TokenDetails")
+            options = Options(token_details=token_details, **kwargs)
         elif ('auth_callback' not in kwargs and 'auth_url' not in kwargs and
               # and don't have both key_name and key_secret
               not ('key_name' in kwargs and 'key_secret' in kwargs)):

--- a/ably/rest/rest.py
+++ b/ably/rest/rest.py
@@ -30,7 +30,7 @@ class AblyRest(object):
 
           **Optional Parameters**
           - `client_id`: Undocumented
-          - `host`: The host to connect to. Defaults to rest.ably.io
+          - `rest_host`: The host to connect to. Defaults to rest.ably.io
           - `port`: The port to connect to. Defaults to 80
           - `tls_port`: The tls_port to connect to. Defaults to 443
           - `tls`: Specifies whether the client should use TLS. Defaults

--- a/ably/transport/defaults.py
+++ b/ably/transport/defaults.py
@@ -12,8 +12,8 @@ class Defaults(object):
         "E.ably-realtime.com",
     ]
 
-    host = "rest.ably.io"
-    ws_host = "realtime.ably.io"
+    rest_host = "rest.ably.io"
+    realtime_host = "realtime.ably.io"
 
     port = 80
     tls_port = 443
@@ -26,11 +26,11 @@ class Defaults(object):
     transports = []  # ["web_socket", "comet"]
 
     @staticmethod
-    def get_host(options):
-        if options.host:
-            return options.host
+    def get_rest_host(options):
+        if options.rest_host:
+            return options.rest_host
         else:
-            return Defaults.host
+            return Defaults.rest_host
 
     @staticmethod
     def get_port(options):
@@ -46,8 +46,8 @@ class Defaults(object):
                 return Defaults.port
 
     @staticmethod
-    def get_fallback_hosts(options):
-        if options.host:
+    def get_fallback_rest_hosts(options):
+        if options.rest_host:
             return []
         else:
             fallback_hosts_copy = list(Defaults.fallback_hosts)

--- a/ably/types/authoptions.py
+++ b/ably/types/authoptions.py
@@ -8,12 +8,13 @@ from ably.util.exceptions import AblyException
 class AuthOptions(object):
     def __init__(self, auth_callback=None, auth_url=None, auth_token=None,
                  auth_headers=None, auth_params=None, key_name=None, key_secret=None,
-                 key=None, query_time=False):
+                 key=None, query_time=False, token_details=None):
         self.__auth_callback = auth_callback
         self.__auth_url = auth_url
         self.__auth_token = auth_token
         self.__auth_headers = auth_headers
         self.__auth_params = auth_params
+        self.__token_details = token_details
         if key is not None:
             self.__key_name, self.__key_secret = self.parse_key(key)
         else:
@@ -117,6 +118,14 @@ class AuthOptions(object):
     @query_time.setter
     def query_time(self, value):
         self.__query_time = value
+
+    @property
+    def token_details(self):
+        return self.__token_details
+
+    @token_details.setter
+    def token_details(self, value):
+        self.__token_details = value
 
     def __unicode__(self):
         return six.text_type(self.__dict__)

--- a/ably/types/options.py
+++ b/ably/types/options.py
@@ -5,9 +5,9 @@ from ably.util.exceptions import AblyException
 
 
 class Options(AuthOptions):
-    def __init__(self, client_id=None, log_level=0, tls=True, host=None,
-                 ws_host=None, port=0, tls_port=0, use_binary_protocol=True,
-                 queue_messages=False, recover=False, **kwargs):
+    def __init__(self, client_id=None, log_level=0, tls=True, rest_host=None,
+                 realtime_host=None, port=0, tls_port=0, use_binary_protocol=True,
+                 queue_messages=False, recover=False, environment=None, **kwargs):
         super(Options, self).__init__(**kwargs)
 
         # TODO check these defaults
@@ -15,13 +15,14 @@ class Options(AuthOptions):
         self.__client_id = client_id
         self.__log_level = log_level
         self.__tls = tls
-        self.__host = host
-        self.__ws_host = ws_host
+        self.__rest_host = rest_host
+        self.__realtime_host = realtime_host
         self.__port = port
         self.__tls_port = tls_port
         self.__use_binary_protocol = use_binary_protocol
         self.__queue_messages = queue_messages
         self.__recover = recover
+        self.__environment = environment
 
     @property
     def client_id(self):
@@ -48,12 +49,12 @@ class Options(AuthOptions):
         self.__tls = value
 
     @property
-    def host(self):
-        return self.__host
+    def rest_host(self):
+        return self.__rest_host
 
-    @host.setter
-    def host(self, value):
-        self.__host = value
+    @rest_host.setter
+    def rest_host(self, value):
+        self.__rest_host = value
 
     @property
     def port(self):
@@ -94,3 +95,7 @@ class Options(AuthOptions):
     @recover.setter
     def recover(self, value):
         self.__recover = value
+
+    @property
+    def environment(self):
+        return self.__environment

--- a/ably/types/options.py
+++ b/ably/types/options.py
@@ -57,6 +57,14 @@ class Options(AuthOptions):
         self.__rest_host = value
 
     @property
+    def realtime_host(self):
+        return self.__realtime_host
+
+    @realtime_host.setter
+    def realtime_host(self, value):
+        self.__realtime_host = value
+
+    @property
     def port(self):
         return self.__port
 

--- a/test/ably/encoders_test.py
+++ b/test/ably/encoders_test.py
@@ -24,7 +24,7 @@ class TestTextEncodersNoEncryption(BaseTestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                            host=test_vars["host"],
+                            rest_host=test_vars["host"],
                             port=test_vars["port"],
                             tls_port=test_vars["tls_port"],
                             tls=test_vars["tls"],
@@ -152,7 +152,7 @@ class TestTextEncodersEncryption(BaseTestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                            host=test_vars["host"],
+                            rest_host=test_vars["host"],
                             port=test_vars["port"],
                             tls_port=test_vars["tls_port"],
                             tls=test_vars["tls"],
@@ -282,7 +282,7 @@ class TestBinaryEncodersNoEncryption(BaseTestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                            host=test_vars["host"],
+                            rest_host=test_vars["host"],
                             port=test_vars["port"],
                             tls_port=test_vars["tls_port"],
                             tls=test_vars["tls"])
@@ -372,7 +372,7 @@ class TestBinaryEncodersEncryption(BaseTestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                            host=test_vars["host"],
+                            rest_host=test_vars["host"],
                             port=test_vars["port"],
                             tls_port=test_vars["tls_port"],
                             tls=test_vars["tls"])

--- a/test/ably/restappstats_test.py
+++ b/test/ably/restappstats_test.py
@@ -35,12 +35,12 @@ class TestRestAppStatsSetup(object):
         RestSetup._RestSetup__test_vars = None
         test_vars = RestSetup.get_test_vars()
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                            host=test_vars["host"],
+                            rest_host=test_vars["host"],
                             port=test_vars["port"],
                             tls_port=test_vars["tls_port"],
                             tls=test_vars["tls"])
         cls.ably_text = AblyRest(key=test_vars["keys"][0]["key_str"],
-                                 host=test_vars["host"],
+                                 rest_host=test_vars["host"],
                                  port=test_vars["port"],
                                  tls_port=test_vars["tls_port"],
                                  tls=test_vars["tls"],

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -44,7 +44,7 @@ class TestAuth(BaseTestCase):
             return "this_is_not_really_a_token_request"
 
         ably = AblyRest(key_name=test_vars["keys"][0]["key_name"],
-                        host=test_vars["host"],
+                        rest_host=test_vars["host"],
                         port=test_vars["port"],
                         tls_port=test_vars["tls_port"],
                         tls=test_vars["tls"],
@@ -70,7 +70,7 @@ class TestAuth(BaseTestCase):
     def test_auth_init_with_token(self):
 
         ably = AblyRest(token="this_is_not_really_a_token",
-                        host=test_vars["host"],
+                        rest_host=test_vars["host"],
                         port=test_vars["port"],
                         tls_port=test_vars["tls_port"],
                         tls=test_vars["tls"])

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -12,7 +12,6 @@ from ably import Auth
 from ably import Options
 from ably.types.tokendetails import TokenDetails
 
-
 from test.ably.restsetup import RestSetup
 from test.ably.utils import BaseTestCase, VaryByProtocolTestsMetaclass, dont_vary_protocol 
 
@@ -35,6 +34,13 @@ class TestAuth(BaseTestCase):
 
         self.assertEqual(Auth.Method.TOKEN, ably.auth.auth_method,
                          msg="Unexpected Auth method mismatch")
+
+    def test_auth_token_details(self):
+        td = TokenDetails()
+        ably = AblyRest(token_details=td)
+
+        self.assertEqual(Auth.Method.TOKEN, ably.auth.auth_method)
+        self.assertIs(ably.auth.token_details, td)
 
     def test_auth_init_with_token_callback(self):
         callback_called = []
@@ -84,7 +90,7 @@ class TestAuthAuthorize(BaseTestCase):
 
     def setUp(self):
         self.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                             host=test_vars["host"],
+                             rest_host=test_vars["host"],
                              port=test_vars["port"],
                              tls_port=test_vars["tls_port"],
                              tls=test_vars["tls"])

--- a/test/ably/restcapability_test.py
+++ b/test/ably/restcapability_test.py
@@ -23,7 +23,7 @@ class TestRestCapability(BaseTestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                            host=test_vars["host"],
+                            rest_host=test_vars["host"],
                             port=test_vars["port"],
                             tls_port=test_vars["tls_port"],
                             tls=test_vars["tls"])

--- a/test/ably/restchannelhistory_test.py
+++ b/test/ably/restchannelhistory_test.py
@@ -24,7 +24,7 @@ class TestRestChannelHistory(BaseTestCase):
     @classmethod
     def setUpClass(cls):
         cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                            host=test_vars["host"],
+                            rest_host=test_vars["host"],
                             port=test_vars["port"],
                             tls_port=test_vars["tls_port"],
                             tls=test_vars["tls"])

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 class TestRestChannelPublish(BaseTestCase):
     def setUp(self):
         self.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                             host=test_vars["host"],
+                             rest_host=test_vars["host"],
                              port=test_vars["port"],
                              tls_port=test_vars["tls_port"],
                              tls=test_vars["tls"])
@@ -117,7 +117,7 @@ class TestRestChannelPublish(BaseTestCase):
         }
 
         ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                        host=test_vars["host"],
+                        rest_host=test_vars["host"],
                         port=test_vars["port"],
                         tls_port=test_vars["tls_port"],
                         tls=test_vars["tls"],

--- a/test/ably/restchannels_test.py
+++ b/test/ably/restchannels_test.py
@@ -21,7 +21,7 @@ class TestChannels(BaseTestCase):
 
     def setUp(self):
         self.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                             host=test_vars["host"],
+                             rest_host=test_vars["host"],
                              port=test_vars["port"],
                              tls_port=test_vars["tls_port"],
                              tls=test_vars["tls"])
@@ -108,7 +108,7 @@ class TestChannels(BaseTestCase):
     def test_without_permissions(self):
         key = test_vars["keys"][2]
         ably = AblyRest(key=key["key_str"],
-                        host=test_vars["host"],
+                        rest_host=test_vars["host"],
                         port=test_vars["port"],
                         tls_port=test_vars["tls_port"],
                         tls=test_vars["tls"])

--- a/test/ably/restcrypto_test.py
+++ b/test/ably/restcrypto_test.py
@@ -28,7 +28,7 @@ class TestRestCrypto(BaseTestCase):
     def setUp(self):
         options = {
             "key": test_vars["keys"][0]["key_str"],
-            "host": test_vars["host"],
+            "rest_host": test_vars["host"],
             "port": test_vars["port"],
             "tls_port": test_vars["tls_port"],
             "tls": test_vars["tls"],

--- a/test/ably/resthttp_test.py
+++ b/test/ably/resthttp_test.py
@@ -76,7 +76,7 @@ class TestRestHttp(BaseTestCase):
                 expected_urls_set = set([
                     make_url(host)
                     for host in ([ably.http.preferred_host] +
-                                 Defaults.get_fallback_hosts(Options()))
+                                 Defaults.get_fallback_rest_hosts(Options()))
                 ])
                 for ((__, url), ___) in request_mock.call_args_list:
                     self.assertIn(url, expected_urls_set)
@@ -84,7 +84,7 @@ class TestRestHttp(BaseTestCase):
 
     def test_no_host_fallback_nor_retries_if_custom_host(self):
         custom_host = 'example.org'
-        ably = AblyRest(token="foo", host=custom_host)
+        ably = AblyRest(token="foo", rest_host=custom_host)
         self.assertIn('max_retry_attempts', ably.http.CONNECTION_RETRY)
 
         custom_url = "%s://%s:%d/" % (
@@ -104,7 +104,7 @@ class TestRestHttp(BaseTestCase):
                     mock.call(mock.ANY, custom_url, data=mock.ANY, headers=mock.ANY))
 
     def test_no_retry_if_not_500_to_599_http_code(self):
-        default_host = Defaults.get_host(Options())
+        default_host = Defaults.get_rest_host(Options())
         ably = AblyRest(token="foo")
         self.assertIn('max_retry_attempts', ably.http.CONNECTION_RETRY)
 

--- a/test/ably/restinit_test.py
+++ b/test/ably/restinit_test.py
@@ -7,6 +7,7 @@ from requests import Session
 from ably import AblyRest
 from ably import AblyException
 from ably.transport.defaults import Defaults
+from ably.types.tokendetails import TokenDetails
 
 from test.ably.restsetup import RestSetup
 from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, BaseTestCase
@@ -32,6 +33,13 @@ class TestRestInit(BaseTestCase):
         ably = AblyRest(token="foo")
         self.assertEqual(ably.options.auth_token, "foo",
                          "Token not set at options")
+
+    @dont_vary_protocol
+    def test_with_token(self):
+        td = TokenDetails()
+        ably = AblyRest(token_details=td)
+        self.assertIs(ably.options.token_details, td)
+
     @dont_vary_protocol
     def test_with_options_token_callback(self):
         def token_callback(**params):
@@ -75,6 +83,20 @@ class TestRestInit(BaseTestCase):
     @dont_vary_protocol
     def test_specified_port(self):
         ably = AblyRest(token='foo', port=9998, tls_port=9999)
+        self.assertEqual(9999, Defaults.get_port(ably.options),
+                         msg="Unexpected port mismatch. Expected: 9999. Actual: %d" %
+                         ably.options.tls_port)
+
+    @dont_vary_protocol
+    def test_specified_non_tls_port(self):
+        ably = AblyRest(token='foo', port=9998, tls=False)
+        self.assertEqual(9998, Defaults.get_port(ably.options),
+                         msg="Unexpected port mismatch. Expected: 9999. Actual: %d" %
+                         ably.options.tls_port)
+
+    @dont_vary_protocol
+    def test_specified_tls_port(self):
+        ably = AblyRest(token='foo', tls_port=9999, tls=True)
         self.assertEqual(9999, Defaults.get_port(ably.options),
                          msg="Unexpected port mismatch. Expected: 9999. Actual: %d" %
                          ably.options.tls_port)

--- a/test/ably/restinit_test.py
+++ b/test/ably/restinit_test.py
@@ -35,7 +35,7 @@ class TestRestInit(BaseTestCase):
                          "Token not set at options")
 
     @dont_vary_protocol
-    def test_with_token(self):
+    def test_with_token_details(self):
         td = TokenDetails()
         ably = AblyRest(token_details=td)
         self.assertIs(ably.options.token_details, td)
@@ -75,10 +75,17 @@ class TestRestInit(BaseTestCase):
         AblyRest(auth_url='not_really_an_url')
 
     @dont_vary_protocol
-    def test_specified_host(self):
+    def test_specified_rest_host(self):
         ably = AblyRest(token='foo', rest_host="some.other.host")
         self.assertEqual("some.other.host", ably.options.rest_host,
                          msg="Unexpected host mismatch")
+
+    @dont_vary_protocol
+    def test_specified_realtime_host(self):
+        ably = AblyRest(token='foo', realtime_host="some.other.host")
+        self.assertEqual("some.other.host", ably.options.realtime_host,
+                         msg="Unexpected host mismatch")
+
 
     @dont_vary_protocol
     def test_specified_port(self):

--- a/test/ably/restpaginatedresult_test.py
+++ b/test/ably/restpaginatedresult_test.py
@@ -26,7 +26,7 @@ class TestPaginatedResult(BaseTestCase):
 
     def setUp(self):
         self.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                             host=test_vars["host"],
+                             rest_host=test_vars["host"],
                              port=test_vars["port"],
                              tls_port=test_vars["tls_port"],
                              tls=test_vars["tls"],

--- a/test/ably/restpresence_test.py
+++ b/test/ably/restpresence_test.py
@@ -26,7 +26,7 @@ class TestPresence(BaseTestCase):
 
     def setUp(self):
         self.ably = AblyRest(test_vars["keys"][0]["key_str"],
-                             host=test_vars["host"],
+                             rest_host=test_vars["host"],
                              port=test_vars["port"],
                              tls_port=test_vars["tls_port"],
                              tls=test_vars["tls"])

--- a/test/ably/restsetup.py
+++ b/test/ably/restsetup.py
@@ -33,7 +33,7 @@ else:
     tls_port = 8081
 
 
-ably = AblyRest(token='not_a_real_token', host=host,
+ably = AblyRest(token='not_a_real_token', rest_host=host,
                 port=port, tls_port=tls_port,
                 tls=tls, use_binary_protocol=False)
 
@@ -74,12 +74,12 @@ class RestSetup:
     def clear_test_vars():
         test_vars = RestSetup.__test_vars
         options = Options(key=test_vars["keys"][0]["key_str"])
-        options.host = test_vars["host"]
+        options.rest_host = test_vars["host"]
         options.port = test_vars["port"]
         options.tls_port = test_vars["tls_port"]
         options.tls = test_vars["tls"]
         ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                        host = test_vars["host"],
+                        rest_host = test_vars["host"],
                         port = test_vars["port"],
                         tls_port = test_vars["tls_port"],
                         tls = test_vars["tls"])

--- a/test/ably/resttime_test.py
+++ b/test/ably/resttime_test.py
@@ -22,7 +22,7 @@ class TestRestTime(BaseTestCase):
 
     def test_time_accuracy(self):
         ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                        host=test_vars["host"],
+                        rest_host=test_vars["host"],
                         port=test_vars["port"],
                         tls_port=test_vars["tls_port"],
                         tls=test_vars["tls"],
@@ -36,7 +36,7 @@ class TestRestTime(BaseTestCase):
 
     def test_time_without_key_or_token(self):
         ably = AblyRest(token='foo',
-                        host=test_vars["host"],
+                        rest_host=test_vars["host"],
                         port=test_vars["port"],
                         tls_port=test_vars["tls_port"],
                         tls=test_vars["tls"],
@@ -51,7 +51,7 @@ class TestRestTime(BaseTestCase):
     @dont_vary_protocol
     def test_time_fails_without_valid_host(self):
         ably = AblyRest(token='foo',
-                        host="this.host.does.not.exist",
+                        rest_host="this.host.does.not.exist",
                         port=test_vars["port"],
                         tls_port=test_vars["tls_port"])
 

--- a/test/ably/resttoken_test.py
+++ b/test/ably/resttoken_test.py
@@ -28,7 +28,7 @@ class TestRestToken(BaseTestCase):
         capability = {"*":["*"]}
         self.permit_all = six.text_type(Capability(capability))
         self.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
-                             host=test_vars["host"],
+                             rest_host=test_vars["host"],
                              port=test_vars["port"],
                              tls_port=test_vars["tls_port"],
                              tls=test_vars["tls"])


### PR DESCRIPTION
* (RSC11) Requests are sent to the default endpoint rest.ably.io. However, if the host option is set, the client will send requests to the specified host. If environment option is configured, the environment name is prefixed to the default host endpoint and the host is set accordingly. For example, if the environment is set to sandbox, then the host endpoint will become sandbox-rest.ably.io

* (TO3) The attributes of ClientOptions consist of:
  * (TO3a) clientId string – the id of the client represented by this instance
  * (TO3d) tls boolean – defaults to true. If false, will not use TLS for all connections
  * (TO3f) useBinaryProtocol boolean – defaults to true. If false, forces the library to use the JSON encoding for REST and Realtime operations, instead of the default binary msgpack encoding
  * (TO3j) Auth option attributes:
    * (TO3j1) key string – Full Ably key string as obtained from dashboard
    * (TO3j2) token string – An authentication token string issued for this application
    * (TO3j3) tokenDetails TokenDetails – An authentication token issued for this application
  * (TO3k) Development environment attributes:
    * (TO3k1) environment string – for development environments only; allows a non-default Ably environment to be used such as sandbox
    * (TO3k2) restHost string – for development environments only; allows a non-default Ably REST host to be specified
    * (TO3k3) realtimeHost string – for development environments only; allows a non-default Ably Realtime host to be specified
    * (TO3k4) port integer – for development environments only; allows a non-default Ably non-TLS port to be specified
    * (TO3k5) tlsPort integer – for development environments only; allows a non-default Ably TLS port to be specified
