### PR TITLE
RSL1g

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ presence_page.items[0].client_id # client_id of first member
 ```python
 token_details = client.auth.request_token()
 token_details.token # => "xVLyHw.CLchevH3hF....MDh9ZC_Q"
-new_client = AblyRest.(token=token_details.token)
+new_client = AblyRest(token=token_details.token)
 
 token_request = client.auth.create_token_request(
     {

--- a/ably/__init__.py
+++ b/ably/__init__.py
@@ -25,4 +25,4 @@ from ably.types.capability import Capability
 from ably.types.channeloptions import ChannelOptions
 from ably.types.options import Options
 from ably.util.crypto import CipherParams
-from ably.util.exceptions import AblyException, AblyAuthException
+from ably.util.exceptions import AblyException, AblyAuthException, IncompatibleClientIdException

--- a/ably/rest/auth.py
+++ b/ably/rest/auth.py
@@ -194,7 +194,7 @@ class Auth(object):
 
         token_request['timestamp'] = int(token_request['timestamp'])
 
-        token_request['ttl'] = (token_params.get('ttl') or TokenDetails.DEFAULTS['ttl']) * 1000
+        token_request['ttl'] = token_params.get('ttl') or TokenDetails.DEFAULTS['ttl']
 
         if token_params.get('capability') is None:
             token_request["capability"] = ""

--- a/ably/rest/auth.py
+++ b/ably/rest/auth.py
@@ -194,7 +194,7 @@ class Auth(object):
 
         token_request['timestamp'] = int(token_request['timestamp'])
 
-        token_request['ttl'] = token_params.get('ttl') or TokenDetails.DEFAULTS['ttl'] * 1000
+        token_request['ttl'] = (token_params.get('ttl') or TokenDetails.DEFAULTS['ttl']) * 1000
 
         if token_params.get('capability') is None:
             token_request["capability"] = ""

--- a/ably/types/tokendetails.py
+++ b/ably/types/tokendetails.py
@@ -11,6 +11,10 @@ from ably.types.capability import Capability
 class TokenDetails(object):
 
     DEFAULTS = {'ttl': 60 * 60}
+    # Buffer in milliseconds before a token is considered unusable
+    # For example, if buffer is 10000ms, the token can no longer be used for
+    # new requests 9000ms before it expires
+    TOKEN_EXPIRY_BUFFER = 15 * 1000
 
     def __init__(self, token=None, expires=None, issued=0,
                  capability=None, client_id=None):
@@ -45,6 +49,12 @@ class TokenDetails(object):
     @property
     def client_id(self):
         return self.__client_id
+
+    def is_expired(self, timestamp):
+        if self.__expires is None:
+            return False
+        else:
+            return self.__expires < timestamp + self.TOKEN_EXPIRY_BUFFER
 
     @staticmethod
     def from_dict(obj):

--- a/ably/types/tokendetails.py
+++ b/ably/types/tokendetails.py
@@ -10,7 +10,7 @@ from ably.types.capability import Capability
 
 class TokenDetails(object):
 
-    DEFAULTS = {'ttl': 60 * 60}
+    DEFAULTS = {'ttl': 60 * 60 * 1000}
     # Buffer in milliseconds before a token is considered unusable
     # For example, if buffer is 10000ms, the token can no longer be used for
     # new requests 9000ms before it expires
@@ -19,7 +19,7 @@ class TokenDetails(object):
     def __init__(self, token=None, expires=None, issued=0,
                  capability=None, client_id=None):
         if expires is None:
-            self.__expires = (time.time() + TokenDetails.DEFAULTS['ttl']) * 1000
+            self.__expires = time.time() * 1000 + TokenDetails.DEFAULTS['ttl']
         else:
             self.__expires = expires
         self.__token = token

--- a/ably/util/exceptions.py
+++ b/ably/util/exceptions.py
@@ -84,3 +84,7 @@ def catch_all(func):
 
 class AblyAuthException(AblyException):
     pass
+
+
+class IncompatibleClientIdException(AblyException):
+    pass

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -147,8 +147,8 @@ class TestAuth(BaseTestCase):
         self.assertEquals(ably.auth.auth_mechanism, Auth.Method.TOKEN)
 
     def test_default_ttl_is_1hour(self):
-        one_hour_in_seconds = 60 * 60
-        self.assertEquals(TokenDetails.DEFAULTS['ttl'], one_hour_in_seconds)
+        one_hour_in_ms = 60 * 60 * 1000
+        self.assertEquals(TokenDetails.DEFAULTS['ttl'], one_hour_in_ms)
 
     def test_with_auth_method(self):
         ably = AblyRest(token='a token', auth_method='POST')
@@ -289,7 +289,7 @@ class TestAuthAuthorize(BaseTestCase):
     def test_force_and_timestamp_are_not_stored(self):
         # authorise once with arbitrary defaults
         token_1 = self.ably.auth.authorise(
-            {'ttl': 555, 'client_id': 'new_id'},
+            {'ttl': 60 * 1000, 'client_id': 'new_id'},
             {'auth_headers': {'a_headers': 'a_value'}})
         self.assertIsInstance(token_1, TokenDetails)
 
@@ -298,7 +298,7 @@ class TestAuthAuthorize(BaseTestCase):
         with mock.patch('ably.rest.auth.TokenRequest',
                         wraps=ably.types.tokenrequest.TokenRequest) as tr_mock:
             token_2 = self.ably.auth.authorise(
-                {'ttl': 555, 'client_id': 'new_id', 'timestamp': timestamp},
+                {'ttl': 60 * 1000, 'client_id': 'new_id', 'timestamp': timestamp},
                 {'auth_headers': {'a_headers': 'a_value'}, 'force': True})
         self.assertIsInstance(token_2, TokenDetails)
         self.assertNotEqual(token_1, token_2)

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -12,6 +12,7 @@ import mock
 import six
 from requests import Session
 
+import ably
 from ably import AblyRest
 from ably import Auth
 from ably import AblyAuthException
@@ -286,18 +287,36 @@ class TestAuthAuthorize(BaseTestCase):
         self.assertEqual(auth_called['auth_headers'], {'a_headers': 'a_value'})
 
     def test_force_and_timestamp_are_not_stored(self):
-        client_id = 'new_id'
-        time = self.ably.time()
-        self.ably.auth.authorise(
-            {'ttl': 555, 'client_id': client_id, 'timestamp': time},
-            {'auth_headers': {'a_headers': 'a_value'}, 'force': True})
-        with mock.patch('ably.rest.auth.Auth.request_token') as request_mock:
-            request_mock.return_value.client_id = client_id
-            self.ably.auth.authorise(force=True)
+        # authorise once with arbitrary defaults
+        token_1 = self.ably.auth.authorise(
+            {'ttl': 555, 'client_id': 'new_id'},
+            {'auth_headers': {'a_headers': 'a_value'}})
+        self.assertIsInstance(token_1, TokenDetails)
 
-        token_called, auth_called = request_mock.call_args
-        self.assertEqual(token_called[0], {'ttl': 555, 'client_id': client_id})
-        self.assertEqual(auth_called['auth_headers'], {'a_headers': 'a_value'})
+        # call authorise again with force and timestamp set
+        timestamp = self.ably.time()
+        with mock.patch('ably.rest.auth.TokenRequest',
+                        wraps=ably.types.tokenrequest.TokenRequest) as tr_mock:
+            token_2 = self.ably.auth.authorise(
+                {'ttl': 555, 'client_id': 'new_id', 'timestamp': timestamp},
+                {'auth_headers': {'a_headers': 'a_value'}, 'force': True})
+        self.assertIsInstance(token_2, TokenDetails)
+        self.assertNotEqual(token_1, token_2)
+        self.assertEqual(tr_mock.call_args[1]['timestamp'], timestamp)
+
+        # call authorise again with no params
+        token_3 = self.ably.auth.authorise()
+        self.assertIsInstance(token_3, TokenDetails)
+        self.assertEqual(token_2, token_3)
+
+        # call authorise again with force
+        with mock.patch('ably.rest.auth.TokenRequest',
+                        wraps=ably.types.tokenrequest.TokenRequest) as tr_mock:
+            token_4 = self.ably.auth.authorise(force=True)
+        self.assertIsInstance(token_4, TokenDetails)
+        self.assertNotEqual(token_2, token_4)
+        self.assertNotEqual(tr_mock.call_args[1]['timestamp'], timestamp)
+
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)
 class TestRequestToken(BaseTestCase):

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -275,26 +275,28 @@ class TestAuthAuthorize(BaseTestCase):
         self.assertEqual(token.client_id, 'my_client_id')
 
     def test_if_parameters_are_stored_and_used_as_defaults(self):
-        self.ably.auth.authorise({'ttl': 555 * 1000, 'client_id': 'new_id'},
+        self.ably.auth.authorise({'ttl': 555, 'client_id': 'new_id'},
                                  {'auth_headers': {'a_headers': 'a_value'}})
         with mock.patch('ably.rest.auth.Auth.request_token',
                         wraps=self.ably.auth.request_token) as request_mock:
             self.ably.auth.authorise(force=True)
 
         token_called, auth_called = request_mock.call_args
-        self.assertEqual(token_called[0], {'ttl': 555 * 1000, 'client_id': 'new_id'})
+        self.assertEqual(token_called[0], {'ttl': 555, 'client_id': 'new_id'})
         self.assertEqual(auth_called['auth_headers'], {'a_headers': 'a_value'})
 
     def test_force_and_timestamp_are_not_stored(self):
+        client_id = 'new_id'
         time = self.ably.time()
         self.ably.auth.authorise(
-            {'ttl': 555, 'client_id': 'new_id', 'timestamp': time},
+            {'ttl': 555, 'client_id': client_id, 'timestamp': time},
             {'auth_headers': {'a_headers': 'a_value'}, 'force': True})
         with mock.patch('ably.rest.auth.Auth.request_token') as request_mock:
+            request_mock.return_value.client_id = client_id
             self.ably.auth.authorise(force=True)
 
         token_called, auth_called = request_mock.call_args
-        self.assertEqual(token_called[0], {'ttl': 555, 'client_id': 'new_id'})
+        self.assertEqual(token_called[0], {'ttl': 555, 'client_id': client_id})
         self.assertEqual(auth_called['auth_headers'], {'a_headers': 'a_value'})
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -220,8 +220,8 @@ class TestAuthAuthorize(BaseTestCase):
 
         token = self.ably.auth.authorise()
 
-        with mock.patch('ably.types.tokendetails.TokenDetails.expires',
-                        new_callable=mock.PropertyMock(return_value=42)):
+        with mock.patch('ably.types.tokendetails.TokenDetails.is_expired',
+                        return_value=True):
             new_token = self.ably.auth.authorise()
 
         self.assertIsNot(token, new_token)
@@ -275,13 +275,14 @@ class TestAuthAuthorize(BaseTestCase):
         self.assertEqual(token.client_id, 'my_client_id')
 
     def test_if_parameters_are_stored_and_used_as_defaults(self):
-        self.ably.auth.authorise({'ttl': 555, 'client_id': 'new_id'},
+        self.ably.auth.authorise({'ttl': 555 * 1000, 'client_id': 'new_id'},
                                  {'auth_headers': {'a_headers': 'a_value'}})
-        with mock.patch('ably.rest.auth.Auth.request_token') as request_mock:
+        with mock.patch('ably.rest.auth.Auth.request_token',
+                        wraps=self.ably.auth.request_token) as request_mock:
             self.ably.auth.authorise(force=True)
 
         token_called, auth_called = request_mock.call_args
-        self.assertEqual(token_called[0], {'ttl': 555, 'client_id': 'new_id'})
+        self.assertEqual(token_called[0], {'ttl': 555 * 1000, 'client_id': 'new_id'})
         self.assertEqual(auth_called['auth_headers'], {'a_headers': 'a_value'})
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)

--- a/test/ably/resttoken_test.py
+++ b/test/ably/resttoken_test.py
@@ -251,7 +251,7 @@ class TestCreateTokenRequest(BaseTestCase):
         token_request = self.ably.auth.create_token_request(
             key_name=self.key_name, key_secret=self.key_secret)
         self.assertEquals(
-            token_request.ttl, TokenDetails.DEFAULTS['ttl'] * 1000)
+            token_request.ttl, TokenDetails.DEFAULTS['ttl'])
 
     @dont_vary_protocol
     def test_accept_all_token_params(self):


### PR DESCRIPTION
```
(RSL1g) Identified clients with a clientId (as a result of either an explicitly configured clientId in ClientOptions, or implicitly through Token Auth):		
	(RSL1g1) When publishing a Message with the clientId attribute set to null	
	  (RSL1g1a) It is unnecessary for the client to set the clientId of the Message before publishing	
	  (RSL1g1b) Ably will not assign a clientId upon receiving the Message. A test should assert via the history API that the clientId value is null for the Message when received	
	(RSL1g2) When publishing a Message with the clientId attribute value set to the identified client’s clientId, Ably will accept the message and publish it. A test should assert that the clientId value is populated for the Message when received	
	(RSL1g3) When publishing a Message with a different clientId attribute value to the identified client’s clientId, the client library should reject the message, and indicate an error. The connection and channel remain available for further operations	
	(RSL1g4) When publishing a message with an explicit clientId that is incompatible with the identified client’s clientId (either inferred or explicitly configured in the token or ClientOptions), the library will reject the message immediately and indicate an error	
```