### PR TITLE
RSA12

### DIFF
--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -453,6 +453,20 @@ class TestRequestToken(BaseTestCase):
         self.assertTrue(responses.calls[0].request.url.endswith(
                         '?with=query&spam=eggs'))
 
+    @dont_vary_protocol
+    def test_client_id_null_for_anonymous_auth(self):
+        ably = AblyRest(
+            key_name=test_vars["keys"][0]["key_name"],
+            key_secret=test_vars["keys"][0]["key_secret"],
+            rest_host=test_vars["host"],
+            port=test_vars["port"],
+            tls_port=test_vars["tls_port"],
+            tls=test_vars["tls"])
+        token = ably.auth.authorise()
+
+        self.assertIsInstance(token, TokenDetails)
+        self.assertIsNone(ably.auth.client_id)
+
 
 class TestRenewToken(BaseTestCase):
 

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -465,6 +465,7 @@ class TestRequestToken(BaseTestCase):
         token = ably.auth.authorise()
 
         self.assertIsInstance(token, TokenDetails)
+        self.assertIsNone(token.client_id)
         self.assertIsNone(ably.auth.client_id)
 
     @dont_vary_protocol

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -467,6 +467,25 @@ class TestRequestToken(BaseTestCase):
         self.assertIsInstance(token, TokenDetails)
         self.assertIsNone(ably.auth.client_id)
 
+    @dont_vary_protocol
+    def test_client_id_null_until_auth(self):
+        client_id = uuid.uuid4().hex
+        token_ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                              rest_host=test_vars["host"],
+                              port=test_vars["port"],
+                              tls_port=test_vars["tls_port"],
+                              tls=test_vars["tls"],
+                              default_token_params={'client_id': client_id})
+        # before auth, client_id is None
+        self.assertIsNone(token_ably.auth.client_id)
+
+        token = token_ably.auth.authorise()
+
+        self.assertIsInstance(token, TokenDetails)
+        # after auth, client_id is defined
+        self.assertEquals(token.client_id, client_id)
+        self.assertEquals(token_ably.auth.client_id, client_id)
+
 
 class TestRenewToken(BaseTestCase):
 


### PR DESCRIPTION
```
(RSA12) Auth#clientId attribute is null when:		
	(RSA12a) The clientId attribute of a TokenRequest or TokenDetails used for authentication is null, or ConnectionDetails#clientId is null following a connection to Ably. In this case, the null value indicates that a clientId identity may not be assumed by this client i.e. the client is anonymous for all operations	
	(RSA12b) The client was instanced without assigning a value for ClientOptions#clientId (null), and the client has not yet authenticated or connected to Ably. In this case, the null value indicates that the client has not yet been able to confirm its identity, and therefore may change and become identified following later authentication or establishment of a connection with Ably	
```