### PR TITLE
RSA7a2

### DIFF
--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -247,6 +247,7 @@ class TestRestChannelPublish(BaseTestCase):
         self.assertIsInstance(self.ably_with_client_id.auth.token_details, TokenDetails)
         self.assertEqual(self.ably_with_client_id.auth.token_details.client_id, self.client_id)
         self.assertEqual(self.ably_with_client_id.auth.auth_mechanism, Auth.Method.TOKEN)
+        self.assertEqual(channel.history().items[0].client_id, self.client_id)
 
     def test_publish_message_without_client_id_on_identified_client(self):
         channel = self.ably_with_client_id.channels[


### PR DESCRIPTION
```
(RSA7a2) If clientId is provided in ClientOptions, and an API key is provided along with no other means to generate a token, the client library will authenticate with Ably and obtain a token using the provided clientId ensuring the token is restricted to operations for that clientId
```
