### PR TITLE
RSA7b4, RSA8f3, RSA8f4

### DIFF
--- a/ably/rest/auth.py
+++ b/ably/rest/auth.py
@@ -27,7 +27,10 @@ class Auth(object):
     def __init__(self, ably, options):
         self.__ably = ably
         self.__auth_options = options
-        self.__client_id = options.client_id
+        if options.token_details:
+            self.__client_id = options.token_details.client_id
+        else:
+            self.__client_id = options.client_id
         self.__client_id_validated = False
 
         self.__basic_credentials = None

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -304,3 +304,29 @@ class TestRestChannelPublish(BaseTestCase):
         the_exception = cm.exception
         self.assertEqual(400, the_exception.status_code)
         self.assertEqual(40012, the_exception.code)
+
+    def test_wildcard_client_id_can_publish_as_others(self):
+        wildcard_token_details = self.ably.auth.request_token({'client_id': '*'})
+        wildcard_ably = AblyRest(token_details=wildcard_token_details,
+                                 rest_host=test_vars["host"],
+                                 port=test_vars["port"],
+                                 tls_port=test_vars["tls_port"],
+                                 tls=test_vars["tls"],
+                                 use_binary_protocol=self.use_binary_protocol)
+
+        self.assertEqual(wildcard_ably.auth.client_id, '*')
+        channel = wildcard_ably.channels[
+            self.protocol_channel_name('persisted:wildcard_client_id')]
+        channel.publish(name='publish1', data='no client_id')
+        some_client_id = uuid.uuid4().hex
+        channel.publish(name='publish2', data='some client_id',
+                        client_id=some_client_id)
+
+        history = channel.history()
+        messages = history.items
+
+        self.assertIsNotNone(messages, msg="Expected non-None messages")
+        self.assertEqual(len(messages), 2, msg="Expected 2 messages")
+
+        self.assertEqual(messages[0].client_id, some_client_id)
+        self.assertIsNone(messages[1].client_id)


### PR DESCRIPTION
```
(RSA7b4) When a wildcard string '*' is present in the TokenRequest, TokenDetails, or ProtocolMessage#connectionDetails object, then the client does not have an identity but is allowed to assume an identity when performing operations with Ably. As such, Auth#clientId should contain the string value '*' indicating that the current client is allowed to perform operations on behalf of any clientId	

(RSA8f3) Request a token with a wildcard '*' value clientId, authenticate a client with the token, publish a message without an explicit clientId, and ensure the message published does not have a clientId. Check that Auth#clientId is a string with value '*'

(RSA8f4) Request a token with a wildcard '*' value clientId, authenticate a client with the token, publish a message with an explicit clientId value, and ensure that the message published has the provided clientId
```