### PR TITLE
RSC7a and RSC7b

### DIFF
--- a/ably/__init__.py
+++ b/ably/__init__.py
@@ -25,3 +25,6 @@ from ably.types.capability import Capability
 from ably.types.options import Options
 from ably.util.crypto import CipherParams
 from ably.util.exceptions import AblyException, AblyAuthException, IncompatibleClientIdException
+
+api_version = '1.0'
+lib_version = '1.0.0-alpha'

--- a/ably/http/http.py
+++ b/ably/http/http.py
@@ -135,10 +135,10 @@ class Http(object):
             body = self.dump_body(native_data)
         if body:
             all_headers = HttpUtils.default_post_headers(
-                self.options.use_binary_protocol)
+                self.options.use_binary_protocol, self.__ably.variant)
         else:
             all_headers = HttpUtils.default_get_headers(
-                self.options.use_binary_protocol)
+                self.options.use_binary_protocol, self.__ably.variant)
 
         if not skip_auth:
             if self.auth.auth_mechanism == Auth.Method.BASIC and self.preferred_scheme.lower() == 'http':

--- a/ably/http/httputils.py
+++ b/ably/http/httputils.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import ably
+
 
 class HttpUtils(object):
     default_format = "json"
@@ -13,24 +15,18 @@ class HttpUtils(object):
 
     @staticmethod
     def default_get_headers(binary=False):
+        headers = {
+            "X-Ably-Version": ably.api_version,
+            "X-Ably-Lib": 'python-%s' % ably.lib_version,
+        }
         if binary:
-            return {
-                "Accept": HttpUtils.mime_types['binary']
-            }
+            headers["Accept"] = HttpUtils.mime_types['binary']
         else:
-            return {
-                "Accept": HttpUtils.mime_types['json']
-            }
+            headers["Accept"] = HttpUtils.mime_types['json']
+        return headers
 
     @staticmethod
     def default_post_headers(binary=False):
-        if binary:
-            return {
-                "Accept": HttpUtils.mime_types['binary'],
-                "Content-Type": HttpUtils.mime_types['binary']
-            }
-        else:
-            return {
-                "Accept": HttpUtils.mime_types['json'],
-                "Content-Type": HttpUtils.mime_types['json']
-            }
+        headers = HttpUtils.default_get_headers(binary=binary)
+        headers["Content-Type"] = headers["Accept"]
+        return headers

--- a/ably/http/httputils.py
+++ b/ably/http/httputils.py
@@ -14,10 +14,15 @@ class HttpUtils(object):
     }
 
     @staticmethod
-    def default_get_headers(binary=False):
+    def default_get_headers(binary=False, variant=None):
+        if variant is not None:
+            lib_version = 'python.%s-%s' % (variant, ably.lib_version)
+        else:
+            lib_version = 'python-%s' % ably.lib_version
+
         headers = {
             "X-Ably-Version": ably.api_version,
-            "X-Ably-Lib": 'python-%s' % ably.lib_version,
+            "X-Ably-Lib": 'python-%s' % lib_version,
         }
         if binary:
             headers["Accept"] = HttpUtils.mime_types['binary']
@@ -26,7 +31,7 @@ class HttpUtils(object):
         return headers
 
     @staticmethod
-    def default_post_headers(binary=False):
-        headers = HttpUtils.default_get_headers(binary=binary)
+    def default_post_headers(binary=False, variant=None):
+        headers = HttpUtils.default_get_headers(binary=binary, variant=variant)
         headers["Content-Type"] = headers["Accept"]
         return headers

--- a/ably/rest/rest.py
+++ b/ably/rest/rest.py
@@ -19,6 +19,9 @@ log = logging.getLogger(__name__)
 
 class AblyRest(object):
     """Ably Rest Client"""
+
+    variant = None
+
     def __init__(self, key=None, token=None, token_details=None, **kwargs):
         """Create an AblyRest instance.
 
@@ -71,6 +74,10 @@ class AblyRest(object):
 
         self.__channels = Channels(self)
         self.__options = options
+
+    def set_variant(self, variant):
+        """Sets library variant as per RSC7b"""
+        self.variant = variant
 
     def _format_time_param(self, t):
         try:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('LONG_DESCRIPTION.rst') as f:
 
 setup(
     name='ably',
-    version='0.8.1',
+    version='1.0.0-alpha',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/test/ably/resthttp_test.py
+++ b/test/ably/resthttp_test.py
@@ -139,10 +139,8 @@ class TestRestHttp(BaseTestCase):
         self.assertEqual(ably.http.http_max_retry_count, 6)
         self.assertEqual(ably.http.http_max_retry_duration, 20)
 
+    # RSC7a, RSC7b
     def test_request_headers(self):
-        """
-        RSC7a, RSC7b
-        """
         ably = AblyRest(key=test_vars["keys"][0]["key_str"],
                         rest_host=test_vars["host"],
                         port=test_vars["port"],

--- a/test/ably/resthttp_test.py
+++ b/test/ably/resthttp_test.py
@@ -6,11 +6,15 @@ import mock
 import requests
 from six.moves.urllib.parse import urljoin
 
+from ably import api_version, lib_version
 from ably import AblyRest
 from ably.transport.defaults import Defaults
 from ably.types.options import Options
 from ably.util.exceptions import AblyException
+from test.ably.restsetup import RestSetup
 from test.ably.utils import BaseTestCase
+
+test_vars = RestSetup.get_test_vars()
 
 
 class TestRestHttp(BaseTestCase):
@@ -135,3 +139,16 @@ class TestRestHttp(BaseTestCase):
         self.assertEqual(ably.http.http_open_timeout, 8)
         self.assertEqual(ably.http.http_max_retry_count, 6)
         self.assertEqual(ably.http.http_max_retry_duration, 20)
+
+    def test_request_headers(self):
+        ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                        rest_host=test_vars["host"],
+                        port=test_vars["port"],
+                        tls_port=test_vars["tls_port"],
+                        tls=test_vars["tls"])
+        r = ably.http.make_request('HEAD', '/time', skip_auth=True)
+        self.assertIn('X-Ably-Version', r.request.headers)
+        self.assertEqual(r.request.headers['X-Ably-Version'], api_version)
+
+        self.assertIn('X-Ably-Lib', r.request.headers)
+        self.assertEqual(r.request.headers['X-Ably-Lib'], 'python-%s' % lib_version)


### PR DESCRIPTION
As a side effect now python-ably has two new variables:

    >>> import ably
    >>> ably.api_version
    '1.0'
    >>> ably.lib_version
    '1.0.0-alpha'