### PR TITLE
Fix Flake8 warnings regarding spacing

### DIFF
--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -289,7 +289,6 @@ class TestAuthAuthorize(BaseTestCase):
         self.assertEqual(token_called[0], {})
         self.assertEqual(auth_called['auth_headers'], None)
 
-
     # RSA10g
     def test_timestamp_is_not_stored(self):
         # authorize once with arbitrary defaults

--- a/test/ably/restrequest_test.py
+++ b/test/ably/restrequest_test.py
@@ -38,14 +38,14 @@ class TestRestRequest(BaseTestCase):
         body = {'name': 'test-post', 'data': 'lorem ipsum'}
         result = self.ably.request('POST', '/channels/test/messages', body=body)
 
-        self.assertIsInstance(result, HttpPaginatedResponse) # RSC19d
+        self.assertIsInstance(result, HttpPaginatedResponse)  # RSC19d
         self.assertEqual(result.items, [])                 # HP3
 
     def test_get(self):
         params = {'limit': 10, 'direction': 'forwards'}
         result = self.ably.request('GET', '/channels/test/messages', params=params)
 
-        self.assertIsInstance(result, HttpPaginatedResponse) # RSC19d
+        self.assertIsInstance(result, HttpPaginatedResponse)  # RSC19d
 
         # HP2
         self.assertIsInstance(result.next(), HttpPaginatedResponse)
@@ -60,25 +60,25 @@ class TestRestRequest(BaseTestCase):
         self.assertEqual(item['name'], 'event0')
         self.assertEqual(item['data'], 'lorem ipsum 0')
 
-        self.assertEqual(result.status_code, 200)    # HP4
-        self.assertEqual(result.success, True)       # HP5
-        self.assertEqual(result.error_code, None)    # HP6
-        self.assertEqual(result.error_message, None) # HP7
-        self.assertIsInstance(result.headers, list)  # HP7
+        self.assertEqual(result.status_code, 200)     # HP4
+        self.assertEqual(result.success, True)        # HP5
+        self.assertEqual(result.error_code, None)     # HP6
+        self.assertEqual(result.error_message, None)  # HP7
+        self.assertIsInstance(result.headers, list)   # HP7
 
     @dont_vary_protocol
     def test_not_found(self):
         result = self.ably.request('GET', '/not-found')
-        self.assertIsInstance(result, HttpPaginatedResponse) # RSC19d
-        self.assertEqual(result.status_code, 404)          # HP4
-        self.assertEqual(result.success, False)            # HP5
+        self.assertIsInstance(result, HttpPaginatedResponse)  # RSC19d
+        self.assertEqual(result.status_code, 404)             # HP4
+        self.assertEqual(result.success, False)               # HP5
 
     @dont_vary_protocol
     def test_error(self):
         params = {'limit': 'abc'}
         result = self.ably.request('GET', '/channels/test/messages', params=params)
-        self.assertIsInstance(result, HttpPaginatedResponse) # RSC19d
-        self.assertEqual(result.status_code, 400) # HP4
+        self.assertIsInstance(result, HttpPaginatedResponse)  # RSC19d
+        self.assertEqual(result.status_code, 400)  # HP4
         self.assertFalse(result.success)
         self.assertTrue(result.error_code)
         self.assertTrue(result.error_message)


### PR DESCRIPTION
flake8
./test/ably/restauth_test.py:293:5: E303 too many blank lines (2)
./test/ably/restrequest_test.py:41:61: E261 at least two spaces before inline comment
./test/ably/restrequest_test.py:48:61: E261 at least two spaces before inline comment
./test/ably/restrequest_test.py:66:53: E261 at least two spaces before inline comment
./test/ably/restrequest_test.py:72:61: E261 at least two spaces before inline comment
./test/ably/restrequest_test.py:80:61: E261 at least two spaces before inline comment
./test/ably/restrequest_test.py:81:50: E261 at least two spaces before inline comment

