### PR TITLE
Fix tests

### DIFF
--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -343,7 +343,7 @@ class TestAuthAuthorize(BaseTestCase):
     # RSA10l
     @dont_vary_protocol
     def test_authorise(self):
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True) as ws:
             # Cause all warnings to always be triggered
             warnings.simplefilter("always")
 
@@ -351,8 +351,8 @@ class TestAuthAuthorize(BaseTestCase):
             self.assertIsInstance(token, TokenDetails)
 
             # Verify warning is raised
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            ws = [w for w in ws if issubclass(w.category, DeprecationWarning)]
+            self.assertEqual(len(ws), 1)
 
 
 @six.add_metaclass(VaryByProtocolTestsMetaclass)

--- a/test/ably/restrequest_test.py
+++ b/test/ably/restrequest_test.py
@@ -98,7 +98,7 @@ class TestRestRequest(BaseTestCase):
     @dont_vary_protocol
     def test_timeout(self):
         # Timeout
-        timeout = 0.00001
+        timeout = 0.000001
         ably = AblyRest(token="foo", http_request_timeout=timeout)
         self.assertEqual(ably.http.http_request_timeout, timeout)
         with self.assertRaises(requests.exceptions.ReadTimeout):

--- a/test/ably/restrequest_test.py
+++ b/test/ably/restrequest_test.py
@@ -28,7 +28,7 @@ class TestRestRequest(BaseTestCase):
         # Populate the channel (using the new api)
         for i in range(20):
             body = {'name': 'event%s' % i, 'data': 'lorem ipsum %s' % i}
-            cls.ably.request('POST', '/channels/test/messages', body=body)
+            cls.ably.request('POST', '/channels/rest-request/messages', body=body)
 
     def per_protocol_setup(self, use_binary_protocol):
         self.ably.options.use_binary_protocol = use_binary_protocol
@@ -36,19 +36,19 @@ class TestRestRequest(BaseTestCase):
 
     def test_post(self):
         body = {'name': 'test-post', 'data': 'lorem ipsum'}
-        result = self.ably.request('POST', '/channels/test/messages', body=body)
+        result = self.ably.request('POST', '/channels/rest-request/messages', body=body)
 
         assert isinstance(result, HttpPaginatedResponse)  # RSC19d
         # HP3
         assert type(result.items) is list
         assert len(result.items) == 1
-        assert result.items[0]['channel'] == 'test'
+        assert result.items[0]['channel'] == 'rest-request'
         assert 'messageId' in result.items[0]
 
 
     def test_get(self):
         params = {'limit': 10, 'direction': 'forwards'}
-        result = self.ably.request('GET', '/channels/test/messages', params=params)
+        result = self.ably.request('GET', '/channels/rest-request/messages', params=params)
 
         self.assertIsInstance(result, HttpPaginatedResponse)  # RSC19d
 
@@ -81,7 +81,7 @@ class TestRestRequest(BaseTestCase):
     @dont_vary_protocol
     def test_error(self):
         params = {'limit': 'abc'}
-        result = self.ably.request('GET', '/channels/test/messages', params=params)
+        result = self.ably.request('GET', '/channels/rest-request/messages', params=params)
         self.assertIsInstance(result, HttpPaginatedResponse)  # RSC19d
         self.assertEqual(result.status_code, 400)  # HP4
         self.assertFalse(result.success)

--- a/test/ably/restrequest_test.py
+++ b/test/ably/restrequest_test.py
@@ -1,6 +1,7 @@
 #import time
+import random
+import string
 
-#import mock
 import requests
 import six
 
@@ -26,9 +27,11 @@ class TestRestRequest(BaseTestCase):
                              tls=test_vars["tls"])
 
         # Populate the channel (using the new api)
+        cls.channel = ''.join([random.choice(string.ascii_letters) for x in range(8)])
+        cls.path = '/channels/%s/messages' % cls.channel
         for i in range(20):
             body = {'name': 'event%s' % i, 'data': 'lorem ipsum %s' % i}
-            cls.ably.request('POST', '/channels/rest-request/messages', body=body)
+            cls.ably.request('POST', cls.path, body=body)
 
     def per_protocol_setup(self, use_binary_protocol):
         self.ably.options.use_binary_protocol = use_binary_protocol
@@ -36,19 +39,19 @@ class TestRestRequest(BaseTestCase):
 
     def test_post(self):
         body = {'name': 'test-post', 'data': 'lorem ipsum'}
-        result = self.ably.request('POST', '/channels/rest-request/messages', body=body)
+        result = self.ably.request('POST', self.path, body=body)
 
         assert isinstance(result, HttpPaginatedResponse)  # RSC19d
         # HP3
         assert type(result.items) is list
         assert len(result.items) == 1
-        assert result.items[0]['channel'] == 'rest-request'
+        assert result.items[0]['channel'] == self.channel
         assert 'messageId' in result.items[0]
 
 
     def test_get(self):
         params = {'limit': 10, 'direction': 'forwards'}
-        result = self.ably.request('GET', '/channels/rest-request/messages', params=params)
+        result = self.ably.request('GET', self.path, params=params)
 
         self.assertIsInstance(result, HttpPaginatedResponse)  # RSC19d
 
@@ -81,7 +84,7 @@ class TestRestRequest(BaseTestCase):
     @dont_vary_protocol
     def test_error(self):
         params = {'limit': 'abc'}
-        result = self.ably.request('GET', '/channels/rest-request/messages', params=params)
+        result = self.ably.request('GET', self.path, params=params)
         self.assertIsInstance(result, HttpPaginatedResponse)  # RSC19d
         self.assertEqual(result.status_code, 400)  # HP4
         self.assertFalse(result.success)


### PR DESCRIPTION
There's another warning now, one raised by msgpack because
``unpackb(..., encoding=encoding)`` has been deprecated,
since version 0.5.2

At first I wanted to update the calls to ``unpackb``, and use the new
``raw=False``, but then we would require 0.5.2 or later, and that version
does not support Python 3.4 any more. So, if we want to support Python
3.4 we have to live with this warning.