### PR TITLE
'Known limitations' section in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@ If you find any compatibility issues, please [do raise an issue](https://github.
 
 Currently, this SDK only supports [Ably REST](https://www.ably.io/documentation/rest). The following are some of the Ably REST features that are *not supported*:
 
-- Feature 1
-- Feature 2
-- Feature 3
+| Feature | Spec reference |
+| --- | --- |
+| Feature 1 | spec |
+| Feature 2 | spec |
+| Feature 3 | spec |
+| Feature 4 | spec |
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,7 @@ If you find any compatibility issues, please [do raise an issue](https://github.
 
 ## Known Limitations
 
-Currently, this SDK only supports [Ably REST](https://www.ably.io/documentation/rest). However, you can use the [MQTT adapter](https://www.ably.io/documentation/mqtt) to implement [Ably's Realtime](https://link-to-matrix-page) features using Python. The following are some of the Ably REST features that are *not supported*:
-
-| Feature | Spec reference |
-| --- | --- |
-| Feature 1 | spec |
-| Feature 2 | spec |
-| Feature 3 | spec |
-| Feature 4 | spec |
+Currently, this SDK only supports [Ably REST](https://www.ably.io/documentation/rest). However, you can use the [MQTT adapter](https://www.ably.io/documentation/mqtt) to implement [Ably's Realtime](https://todo-link-to-matrix-page) features using Python. 
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you find any compatibility issues, please [do raise an issue](https://github.
 
 ## Known Limitations
 
-Currently, this SDK only supports [Ably REST](https://www.ably.io/documentation/rest). The following are some of the Ably REST features that are *not supported*:
+Currently, this SDK only supports [Ably REST](https://www.ably.io/documentation/rest). However, you can use the [MQTT adapter](https://www.ably.io/documentation/mqtt) to implement [Ably's Realtime](https://link-to-matrix-page) features using Python. The following are some of the Ably REST features that are *not supported*:
 
 | Feature | Spec reference |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ably-python
 
 [![Coverage Status](https://coveralls.io/repos/ably/ably-python/badge.svg?branch=master&service=github)](https://coveralls.io/github/ably/ably-python?branch=master)
 
-A Python client library for [www.ably.io](https://www.ably.io), the realtime messaging service.
+A Python client library for [www.ably.io](https://www.ably.io), the realtime messaging service. This library currently targets the [Ably 1.1 client library specification](https://www.ably.io/documentation/client-lib-development-guide/features/). You can jump to the '[Known Limitations](#known-limitations)' section to see the features this client library does not yet support.
 
 ## Supported platforms
 
@@ -12,6 +12,14 @@ This SDK supports Python 2.7 and 3.4+.
 We regression-test the SDK against a selection of Python versions (which we update over time, but usually consists of mainstream and widely used versions). Please refer to [.travis.yml](./.travis.yml) for the set of versions that currently undergo CI testing.
 
 If you find any compatibility issues, please [do raise an issue](https://github.com/ably/ably-python/issues/new) in this repository or [contact Ably customer support](https://support.ably.io/) for advice.
+
+## Known Limitations
+
+Currently, this SDK only supports [Ably REST](https://www.ably.io/documentation/rest). The following are some of the Ably REST features that are *not supported*:
+
+- Feature 1
+- Feature 2
+- Feature 3
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ably-python
 
 [![Coverage Status](https://coveralls.io/repos/ably/ably-python/badge.svg?branch=master&service=github)](https://coveralls.io/github/ably/ably-python?branch=master)
 
-A Python client library for [www.ably.io](https://www.ably.io), the realtime messaging service. This library currently targets the [Ably 1.1 client library specification](https://www.ably.io/documentation/client-lib-development-guide/features/). You can jump to the '[Known Limitations](#known-limitations)' section to see the features this client library does not yet support (if any).
+A Python client library for [www.ably.io](https://www.ably.io), the realtime messaging service. This library currently targets the [Ably 1.1 client library specification](https://www.ably.io/documentation/client-lib-development-guide/features/). You can jump to the '[Known Limitations](#known-limitations)' section to see the features this client library does not yet support (if any) or visit the [Feature Support Matrix](https://www.ably.io/feature-support-matrix) to see the list of all the available features.
 
 ## Supported platforms
 
@@ -15,7 +15,7 @@ If you find any compatibility issues, please [do raise an issue](https://github.
 
 ## Known Limitations
 
-Currently, this SDK only supports [Ably REST](https://www.ably.io/documentation/rest). However, you can use the [MQTT adapter](https://www.ably.io/documentation/mqtt) to implement [Ably's Realtime](https://todo-link-to-matrix-page) features using Python. 
+Currently, this SDK only supports [Ably REST](https://www.ably.io/documentation/rest). However, you can use the [MQTT adapter](https://www.ably.io/documentation/mqtt) to implement [Ably's Realtime](https://www.ably.io/documentation/realtime) features using Python. 
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ably-python
 
 [![Coverage Status](https://coveralls.io/repos/ably/ably-python/badge.svg?branch=master&service=github)](https://coveralls.io/github/ably/ably-python?branch=master)
 
-A Python client library for [www.ably.io](https://www.ably.io), the realtime messaging service. This library currently targets the [Ably 1.1 client library specification](https://www.ably.io/documentation/client-lib-development-guide/features/). You can jump to the '[Known Limitations](#known-limitations)' section to see the features this client library does not yet support (if any) or visit the [Feature Support Matrix](https://www.ably.io/feature-support-matrix) to see the list of all the available features.
+A Python client library for [www.ably.io](https://www.ably.io), the realtime messaging service. This library currently targets the [Ably 1.1 client library specification](https://www.ably.io/documentation/client-lib-development-guide/features/). You can jump to the '[Known Limitations](#known-limitations)' section to see the features this client library does not yet support (if any) or [view our client library SDKs feature support matrix](https://www.ably.io/download/sdk-feature-support-matrix) to see the list of all the available features.
 
 ## Supported platforms
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ably-python
 
 [![Coverage Status](https://coveralls.io/repos/ably/ably-python/badge.svg?branch=master&service=github)](https://coveralls.io/github/ably/ably-python?branch=master)
 
-A Python client library for [www.ably.io](https://www.ably.io), the realtime messaging service. This library currently targets the [Ably 1.1 client library specification](https://www.ably.io/documentation/client-lib-development-guide/features/). You can jump to the '[Known Limitations](#known-limitations)' section to see the features this client library does not yet support.
+A Python client library for [www.ably.io](https://www.ably.io), the realtime messaging service. This library currently targets the [Ably 1.1 client library specification](https://www.ably.io/documentation/client-lib-development-guide/features/). You can jump to the '[Known Limitations](#known-limitations)' section to see the features this client library does not yet support (if any).
 
 ## Supported platforms
 


### PR DESCRIPTION
This change is per the discussion about the inclusion of unsupported features in the READMEs of various client libraries: [ably/docs#382](https://github.com/ably/docs/issues/382)