### PR TITLE
bump msgpack version to 1.0.0 and update tests

### DIFF
--- a/ably/http/http.py
+++ b/ably/http/http.py
@@ -96,7 +96,7 @@ class Response(object):
 
         content_type = self.__response.headers.get('content-type')
         if content_type == 'application/x-msgpack':
-            return msgpack.unpackb(content, encoding='utf-8')
+            return msgpack.unpackb(content)
         elif content_type == 'application/json':
             return self.__response.json()
         else:

--- a/ably/http/http.py
+++ b/ably/http/http.py
@@ -96,7 +96,7 @@ class Response(object):
 
         content_type = self.__response.headers.get('content-type')
         if content_type == 'application/x-msgpack':
-            return msgpack.unpackb(content)
+            return msgpack.unpackb(content, encoding='utf-8')
         elif content_type == 'application/json':
             return self.__response.json()
         else:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 methoddispatch>=3.0.2,<4
-msgpack-python>=0.4.6
+msgpack==1.0.0
 pycryptodome
 requests>=2.7.0,<3
 six>=1.9.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 methoddispatch>=3.0.2,<4
-msgpack==1.0.0
+msgpack>=1.0.0,<2
 pycryptodome
 requests>=2.7.0,<3
 six>=1.9.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=['ably', 'ably.http', 'ably.rest', 'ably.transport',
               'ably.types', 'ably.util'],
     install_requires=['methoddispatch>=3.0.2,<4',
-                      'msgpack-python>=0.4.6',
+                      'msgpack==1.0.0',
                       'requests>=2.7.0,<3',
                       'six>=1.9.0'],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=['ably', 'ably.http', 'ably.rest', 'ably.transport',
               'ably.types', 'ably.util'],
     install_requires=['methoddispatch>=3.0.2,<4',
-                      'msgpack==1.0.0',
+                      'msgpack>=1.0.0,<2',
                       'requests>=2.7.0,<3',
                       'six>=1.9.0'],
     extras_require={

--- a/test/ably/encoders_test.py
+++ b/test/ably/encoders_test.py
@@ -246,7 +246,7 @@ class TestBinaryEncodersNoEncryption(BaseTestCase):
         cls.ably = RestSetup.get_ably_rest()
 
     def decode(self, data):
-        return msgpack.unpackb(data, encoding='utf-8')
+        return msgpack.unpackb(data)
 
     def test_text_utf8(self):
         channel = self.ably.channels["persisted:publish"]
@@ -336,7 +336,7 @@ class TestBinaryEncodersEncryption(BaseTestCase):
         return cipher.decrypt(payload)
 
     def decode(self, data):
-        return msgpack.unpackb(data, encoding='utf-8')
+        return msgpack.unpackb(data)
 
     def test_text_utf8(self):
         channel = self.ably.channels.get("persisted:publish_enc",

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -108,7 +108,7 @@ class TestRestChannelPublish(BaseTestCase):
         assert post_mock.call_count == 1
 
         if self.use_binary_protocol:
-            messages = msgpack.unpackb(post_mock.call_args[1]['body'], encoding='utf-8')
+            messages = msgpack.unpackb(post_mock.call_args[1]['body'])
         else:
             messages = json.loads(post_mock.call_args[1]['body'])
 
@@ -195,7 +195,7 @@ class TestRestChannelPublish(BaseTestCase):
             assert post_mock.call_count == 1
 
             if self.use_binary_protocol:
-                posted_body = msgpack.unpackb(post_mock.call_args[1]['body'], encoding='utf-8')
+                posted_body = msgpack.unpackb(post_mock.call_args[1]['body'])
             else:
                 posted_body = json.loads(post_mock.call_args[1]['body'])
 
@@ -255,7 +255,7 @@ class TestRestChannelPublish(BaseTestCase):
 
             if self.use_binary_protocol:
                 posted_body = msgpack.unpackb(
-                    post_mock.mock_calls[0][2]['body'], encoding='utf-8')
+                    post_mock.mock_calls[0][2]['body'])
             else:
                 posted_body = json.loads(
                     post_mock.mock_calls[0][2]['body'])

--- a/test/ably/utils.py
+++ b/test/ably/utils.py
@@ -71,7 +71,7 @@ def assert_responses_type(protocol):
                 else:
                     assert response.headers['content-type'] == 'application/x-msgpack'
                     if response.content:
-                        msgpack.unpackb(response.content, encoding='utf-8')
+                        msgpack.unpackb(response.content)
 
         return test_decorated
     return test_decorator


### PR DESCRIPTION
Since the release of msgpack 1.0.0, the name of the lib in pypi is now msgpack instead of msgpack-python.
For avoiding compatiblity issues between ably-python and other lib using msgpack (like firebase-admin), I would like to propose to update the msgpack version required by ably-python.

The only change to make was to remove the encoding params when calling msgpack.unpackb(data).

Like in ably/http.py 

From 
`
if content_type == 'application/x-msgpack':
            return msgpack.unpackb(content, encoding='utf-8')
`

To

`
if content_type == 'application/x-msgpack':
            return msgpack.unpackb(content)
`

I ran all the tests with python 3.7.4 and python 2.7.16