### PR TITLE
Remove Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,3 @@ install:
   - travis_retry pip install -r requirements-test.txt
 script:
   - py.test --flake8
-after_success:
-  - "if [ $TRAVIS_PYTHON_VERSION == '3.6' ]; then pip install coveralls; coveralls; fi"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ ably-python
 -----------
 
 [![PyPI version](https://badge.fury.io/py/ably.svg)](https://badge.fury.io/py/ably)
-[![Coverage Status](https://coveralls.io/repos/ably/ably-python/badge.svg?branch=main&service=github)](https://coveralls.io/github/ably/ably-python?branch=main)
 
 A Python client library for [www.ably.io](https://www.ably.io), the realtime messaging service. This library currently targets the [Ably 1.1 client library specification](https://www.ably.io/documentation/client-lib-development-guide/features/). You can jump to the '[Known Limitations](#known-limitations)' section to see the features this client library does not yet support (if any) or [view our client library SDKs feature support matrix](https://www.ably.io/download/sdk-feature-support-matrix) to see the list of all the available features.
 


### PR DESCRIPTION
Status badge was always red and at 0%.

Also, we're going to replace Travis with GitHub Actions very soon: see https://github.com/ably/ably-python/pull/164.