### PR TITLE
RSC7d - Support for Ably-Agent header

### DIFF
--- a/ably/http/http.py
+++ b/ably/http/http.py
@@ -164,11 +164,9 @@ class Http:
             body = self.dump_body(body)
 
         if body:
-            all_headers = HttpUtils.default_post_headers(
-                self.options.use_binary_protocol, self.__ably.variant)
+            all_headers = HttpUtils.default_post_headers(self.options.use_binary_protocol)
         else:
-            all_headers = HttpUtils.default_get_headers(
-                self.options.use_binary_protocol, self.__ably.variant)
+            all_headers = HttpUtils.default_get_headers(self.options.use_binary_protocol)
 
         if not skip_auth:
             if self.auth.auth_mechanism == Auth.Method.BASIC and self.preferred_scheme.lower() == 'http':

--- a/ably/http/httputils.py
+++ b/ably/http/httputils.py
@@ -17,7 +17,7 @@ class HttpUtils:
     def default_get_headers(binary=False):
         headers = {
             "X-Ably-Version": ably.api_version,
-            "Ably-Agent": 'ably-python/%s python/%s ably-python-rest' % (ably.lib_version, platform.python_version())
+            "Ably-Agent": 'ably-python/%s python/%s' % (ably.lib_version, platform.python_version())
         }
         if binary:
             headers["Accept"] = HttpUtils.mime_types['binary']

--- a/ably/http/httputils.py
+++ b/ably/http/httputils.py
@@ -1,3 +1,5 @@
+import platform
+
 import ably
 
 
@@ -12,15 +14,10 @@ class HttpUtils:
     }
 
     @staticmethod
-    def default_get_headers(binary=False, variant=None):
-        if variant is not None:
-            lib_version = 'python.%s-%s' % (variant, ably.lib_version)
-        else:
-            lib_version = 'python-%s' % ably.lib_version
-
+    def default_get_headers(binary=False):
         headers = {
             "X-Ably-Version": ably.api_version,
-            "X-Ably-Lib": lib_version,
+            "Ably-Agent": 'ably-python/%s python/%s ably-python-rest' % (ably.lib_version, platform.python_version())
         }
         if binary:
             headers["Accept"] = HttpUtils.mime_types['binary']
@@ -29,7 +26,7 @@ class HttpUtils:
         return headers
 
     @staticmethod
-    def default_post_headers(binary=False, variant=None):
-        headers = HttpUtils.default_get_headers(binary=binary, variant=variant)
+    def default_post_headers(binary=False):
+        headers = HttpUtils.default_get_headers(binary=binary)
         headers["Content-Type"] = headers["Accept"]
         return headers

--- a/ably/rest/rest.py
+++ b/ably/rest/rest.py
@@ -18,8 +18,6 @@ log = logging.getLogger(__name__)
 class AblyRest:
     """Ably Rest Client"""
 
-    variant = None
-
     def __init__(self, key=None, token=None, token_details=None, **kwargs):
         """Create an AblyRest instance.
 
@@ -69,10 +67,6 @@ class AblyRest:
         self.__channels = Channels(self)
         self.__options = options
         self.__push = Push(self)
-
-    def set_variant(self, variant):
-        """Sets library variant as per RSC7b"""
-        self.variant = variant
 
     @catch_all
     def stats(self, direction=None, start=None, end=None, params=None,

--- a/test/ably/resthttp_test.py
+++ b/test/ably/resthttp_test.py
@@ -188,5 +188,5 @@ class TestRestHttp(BaseTestCase):
 
         # Agent
         assert 'Ably-Agent' in r.request.headers
-        expr = r"^ably-python\/\d.\d.\d python\/\d.\d+.\d+ ably-python-rest$"
+        expr = r"^ably-python\/\d.\d.\d python\/\d.\d+.\d+$"
         assert re.search(expr, r.request.headers['Ably-Agent'])

--- a/test/ably/resthttp_test.py
+++ b/test/ably/resthttp_test.py
@@ -177,7 +177,7 @@ class TestRestHttp(BaseTestCase):
         assert ably.http.http_max_retry_count == 6
         assert ably.http.http_max_retry_duration == 20
 
-    # RSC7a, RSC7b
+    # RSC7a, RSC7d
     def test_request_headers(self):
         ably = RestSetup.get_ably_rest()
         r = ably.http.make_request('HEAD', '/time', skip_auth=True)
@@ -186,13 +186,8 @@ class TestRestHttp(BaseTestCase):
         assert 'X-Ably-Version' in r.request.headers
         assert r.request.headers['X-Ably-Version'] == '1.1'
 
-        # Lib
-        assert 'X-Ably-Lib' in r.request.headers
-        expr = r"^python-1\.1\.\d+(-\w+)?$"
-        assert re.search(expr, r.request.headers['X-Ably-Lib'])
-
-        # Lib Variant
-        ably.set_variant('django')
-        r = ably.http.make_request('HEAD', '/time', skip_auth=True)
-        expr = r"^python.django-1\.1\.\d+(-\w+)?$"
-        assert re.search(expr, r.request.headers['X-Ably-Lib'])
+        # Agent
+        assert 'Ably-Agent' in r.request.headers
+        print(r.request.headers)
+        expr = r"^ably-python\/\d.\d.\d python\/\d.\d.\d ably-python-rest$"
+        assert re.search(expr, r.request.headers['Ably-Agent'])

--- a/test/ably/resthttp_test.py
+++ b/test/ably/resthttp_test.py
@@ -188,6 +188,5 @@ class TestRestHttp(BaseTestCase):
 
         # Agent
         assert 'Ably-Agent' in r.request.headers
-        print(r.request.headers)
         expr = r"^ably-python\/\d.\d.\d python\/\d.\d.\d ably-python-rest$"
         assert re.search(expr, r.request.headers['Ably-Agent'])

--- a/test/ably/resthttp_test.py
+++ b/test/ably/resthttp_test.py
@@ -188,5 +188,5 @@ class TestRestHttp(BaseTestCase):
 
         # Agent
         assert 'Ably-Agent' in r.request.headers
-        expr = r"^ably-python\/\d.\d.\d python\/\d.\d.\d ably-python-rest$"
+        expr = r"^ably-python\/\d.\d.\d python\/\d.\d+.\d+ ably-python-rest$"
         assert re.search(expr, r.request.headers['Ably-Agent'])


### PR DESCRIPTION
#168
https://github.com/ably/docs/pull/1034

- Removed X-Ably-Lib header param
- Added Ably-Agent header param to the REST client headers
- Removed AblyRest.set_variant(): RSC7b