### PR TITLE
Support for environments fallbacks

### DIFF
--- a/ably/http/http.py
+++ b/ably/http/http.py
@@ -190,6 +190,7 @@ class Http:
                                        host,
                                        self.preferred_port)
             url = urljoin(base_url, path)
+            all_headers.update(HttpUtils.get_host_header(host))
             request = requests.Request(method, url, data=body, headers=all_headers)
             prepped = self.__session.prepare_request(request)
             try:

--- a/ably/http/httputils.py
+++ b/ably/http/httputils.py
@@ -33,3 +33,9 @@ class HttpUtils:
         headers = HttpUtils.default_get_headers(binary=binary, variant=variant)
         headers["Content-Type"] = headers["Accept"]
         return headers
+
+    @staticmethod
+    def get_host_header(host):
+        return {
+            'Host': host,
+        }

--- a/ably/transport/defaults.py
+++ b/ably/transport/defaults.py
@@ -45,3 +45,13 @@ class Defaults:
             return "https"
         else:
             return "http"
+
+    @staticmethod
+    def get_environment_fallback_hosts(environment):
+        return [
+            environment + "-a-fallback.ably-realtime.com",
+            environment + "-b-fallback.ably-realtime.com",
+            environment + "-c-fallback.ably-realtime.com",
+            environment + "-d-fallback.ably-realtime.com",
+            environment + "-e-fallback.ably-realtime.com",
+        ]

--- a/ably/types/options.py
+++ b/ably/types/options.py
@@ -1,4 +1,5 @@
 import random
+import warnings
 
 from ably.transport.defaults import Defaults
 from ably.types.authoptions import AuthOptions
@@ -208,8 +209,24 @@ class Options(AuthOptions):
         if fallback_hosts is None:
             if host == Defaults.rest_host or self.fallback_hosts_use_default:
                 fallback_hosts = Defaults.fallback_hosts
+            elif environment != 'production':
+                fallback_hosts = Defaults.get_environment_fallback_hosts(environment)
             else:
                 fallback_hosts = []
+
+        # Explicit warning about deprecating the option
+        if self.fallback_hosts_use_default:
+            if environment != Defaults.environment:
+                warnings.warn(
+                    "There is no longer need to set fallback_hosts_use_default,"
+                    "it will now generate the correct fallback hosts based on environment, fallback_hosts: {}"
+                    .format(','.join(fallback_hosts)), DeprecationWarning
+                )
+            else:
+                warnings.warn(
+                    "There is no longer need to set fallback_hosts_use_default, fallback_hosts: {}"
+                    .format(','.join(fallback_hosts)), DeprecationWarning
+                )
 
         # Shuffle
         fallback_hosts = list(fallback_hosts)

--- a/ably/types/options.py
+++ b/ably/types/options.py
@@ -218,13 +218,13 @@ class Options(AuthOptions):
         if self.fallback_hosts_use_default:
             if environment != Defaults.environment:
                 warnings.warn(
-                    "There is no longer need to set fallback_hosts_use_default,"
-                    "it will now generate the correct fallback hosts based on environment, fallback_hosts: {}"
+                    "It is no longer required to set 'fallback_hosts_use_default', the correct fallback hosts are now "
+                    "inferred from the environment, 'fallback_hosts': {}"
                     .format(','.join(fallback_hosts)), DeprecationWarning
                 )
             else:
                 warnings.warn(
-                    "There is no longer need to set fallback_hosts_use_default, fallback_hosts: {}"
+                    "It is no longer required to set 'fallback_hosts_use_default': 'fallback_hosts': {}"
                     .format(','.join(fallback_hosts)), DeprecationWarning
                 )
 

--- a/test/ably/resthttp_test.py
+++ b/test/ably/resthttp_test.py
@@ -74,6 +74,11 @@ class TestRestHttp(BaseTestCase):
                     assert url in expected_urls_set
                     expected_urls_set.remove(url)
 
+                expected_hosts_set = set(Options(http_max_retry_count=10).get_rest_hosts())
+                for (prep_request_tuple, _) in send_mock.call_args_list:
+                    assert prep_request_tuple[0].headers.get('Host') in expected_hosts_set
+                    expected_hosts_set.remove(prep_request_tuple[0].headers.get('Host'))
+
     def test_no_host_fallback_nor_retries_if_custom_host(self):
         custom_host = 'example.org'
         ably = AblyRest(token="foo", rest_host=custom_host)

--- a/test/ably/restinit_test.py
+++ b/test/ably/restinit_test.py
@@ -1,3 +1,4 @@
+import warnings
 from mock import patch
 import pytest
 from requests import Session
@@ -95,17 +96,23 @@ class TestRestInit(BaseTestCase, metaclass=VaryByProtocolTestsMetaclass):
             [],
         ]
 
+        # Fallback hosts specified (RSC15g1)
         for aux in fallback_hosts:
             ably = AblyRest(token='foo', fallback_hosts=aux)
             assert sorted(aux) == sorted(ably.options.get_fallback_rest_hosts())
 
-        # Specify environment
-        ably = AblyRest(token='foo', environment='sandbox')
-        assert [] == sorted(ably.options.get_fallback_rest_hosts())
+        # Specify environment (RSC15g2)
+        ably = AblyRest(token='foo', environment='sandbox', http_max_retry_count=10)
+        assert sorted(Defaults.get_environment_fallback_hosts('sandbox')) == sorted(
+            ably.options.get_fallback_rest_hosts())
 
-        # Specify environment and fallback_hosts_use_default
+        # Fallback hosts and environment not specified (RSC15g3)
+        ably = AblyRest(token='foo', http_max_retry_count=10)
+        assert sorted(Defaults.fallback_hosts) == sorted(ably.options.get_fallback_rest_hosts())
+
+        # Specify environment and fallback_hosts_use_default, no fallback hosts (RSC15g4)
         # We specify http_max_retry_count=10 so all the fallback hosts get in the list
-        ably = AblyRest(token='foo', environment='sandbox', fallback_hosts_use_default=True,
+        ably = AblyRest(token='foo', environment='not_considered', fallback_hosts_use_default=True,
                         http_max_retry_count=10)
         assert sorted(Defaults.fallback_hosts) == sorted(ably.options.get_fallback_rest_hosts())
 
@@ -114,6 +121,14 @@ class TestRestInit(BaseTestCase, metaclass=VaryByProtocolTestsMetaclass):
         assert 600000 == ably.options.fallback_retry_timeout
         ably = AblyRest(token='foo', fallback_retry_timeout=1000)
         assert 1000 == ably.options.fallback_retry_timeout
+
+        with warnings.catch_warnings(record=True) as ws:
+            # Cause all warnings to always be triggered
+            warnings.simplefilter("always")
+            AblyRest(token='foo', fallback_hosts_use_default=True)
+            # Verify warning is raised for fallback_hosts_use_default
+            ws = [w for w in ws if issubclass(w.category, DeprecationWarning)]
+            assert len(ws) == 1
 
     @dont_vary_protocol
     def test_specified_realtime_host(self):
@@ -199,7 +214,7 @@ class TestRestInit(BaseTestCase, metaclass=VaryByProtocolTestsMetaclass):
         assert 'Cannot use Basic Auth over non-TLS connections' == excinfo.value.message
 
     @dont_vary_protocol
-    def test_enviroment(self):
+    def test_environment(self):
         ably = AblyRest(token='token', environment='custom')
         with patch.object(Session, 'prepare_request',
                           wraps=ably.http._Http__session.prepare_request) as get_mock:


### PR DESCRIPTION
https://github.com/ably/ably-python/issues/155
https://github.com/ably/docs/pull/965

- Deprecating the `fallbackHostsUseDefault` with warning
- Use fallback hosts when specified
- Backward compatibility for the `fallbackHostsUseDefault`
- Fallback hosts per environment when `environment` is set to value other than `production` and `fallbackHosts` not set
- Typo in test method
- Adding `Host` header in every request