### PR TITLE
[#149] Specifying clientId does not force token auth

### DIFF
--- a/ably/rest/auth.py
+++ b/ably/rest/auth.py
@@ -38,7 +38,7 @@ class Auth:
 
         must_use_token_auth = options.use_token_auth is True
         must_not_use_token_auth = options.use_token_auth is False
-        can_use_basic_auth = options.key_secret is not None and options.client_id is None
+        can_use_basic_auth = options.key_secret is not None
         if not must_use_token_auth and can_use_basic_auth:
             # We have the key, no need to authenticate the client
             # default to using basic auth
@@ -314,6 +314,12 @@ class Auth:
 
     async def _get_auth_headers(self):
         if self.__auth_mechanism == Auth.Method.BASIC:
+            # RSA7e2
+            if self.client_id:
+                return {
+                    'Authorization': 'Basic %s' % self.basic_credentials,
+                    'X-Ably-ClientId': base64.b64encode(self.client_id.encode('utf-8'))
+                }
             return {
                 'Authorization': 'Basic %s' % self.basic_credentials,
             }

--- a/ably/types/stats.py
+++ b/ably/types/stats.py
@@ -168,7 +168,7 @@ def granularity_from_interval_id(interval_id):
             return key
         except ValueError:
             pass
-    raise ValueError("Unsuported intervalId")
+    raise ValueError("Unsupported intervalId")
 
 
 def interval_from_interval_id(interval_id):

--- a/test/ably/conftest.py
+++ b/test/ably/conftest.py
@@ -1,9 +1,12 @@
+import asyncio
+
 import pytest
 from test.ably.restsetup import RestSetup
 
 
 @pytest.fixture(scope='session', autouse=True)
-async def setup():
-    await RestSetup.get_test_vars()
-    yield
-    await RestSetup.clear_test_vars()
+def event_loop():
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    loop.run_until_complete(RestSetup.get_test_vars())
+    yield loop
+    loop.run_until_complete(RestSetup.clear_test_vars())

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -29,7 +29,7 @@ class TestRestChannelPublish(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMet
         self.test_vars = await RestSetup.get_test_vars()
         self.ably = await RestSetup.get_ably_rest()
         self.client_id = uuid.uuid4().hex
-        self.ably_with_client_id = await RestSetup.get_ably_rest(client_id=self.client_id)
+        self.ably_with_client_id = await RestSetup.get_ably_rest(client_id=self.client_id, use_token_auth=True)
 
     async def tearDown(self):
         await self.ably.close()

--- a/test/ably/restsetup.py
+++ b/test/ably/restsetup.py
@@ -90,3 +90,4 @@ class RestSetup:
         ably = await cls.get_ably_rest()
         await ably.http.delete('/apps/' + test_vars['app_id'])
         RestSetup.__test_vars = None
+        await ably.close()


### PR DESCRIPTION
#149
This pull request introduces the following changes:
- Not forcing using token auth with clientId
- Changes global tests setup and teardown to be compliant with async
- Typo fixes