### PR TITLE
Conform release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,10 +21,23 @@ pytest test
 
 ## Release Process
 
-1. Update [`setup.py`](./setup.py) and [`ably/__init__.py`](./ably/__init__.py) with the new version number
-2. Run [`github_changelog_generator`](https://github.com/skywinder/Github-Changelog-Generator) to automate the update of the [CHANGELOG](./CHANGELOG.md). Once the CHANGELOG has completed, manually change the `Unreleased` heading and link with the current version number such as `v1.0.0`. Also ensure that the `Full Changelog` link points to the new version tag instead of the `HEAD`.
-3. Commit
-4. Run `python setup.py sdist upload -r ably` to build and upload this new package to PyPi
-5. Tag the new version such as `git tag v1.0.0`
-6. Visit https://github.com/ably/ably-python/tags and add release notes for the release including links to the changelog entry.
-7. Push the tag to origin `git push origin v1.0.0`
+Releases should always be made through a release pull request (PR), which needs to bump the version number and add to the [change log](CHANGELOG.md).
+
+The release process must include the following steps:
+
+1. Ensure that all work intended for this release has landed to `main`
+2. Create a release branch named like `release/1.2.3`
+3. Add a commit to bump the version number, updating [`setup.py`](./setup.py) and [`ably/__init__.py`](./ably/__init__.py)
+4. Add a commit to update the change log
+5. Push the release branch to GitHub
+6. Open a PR for the release against the release branch you just pushed
+7. Gain approval(s) for the release PR from maintainer(s)
+8. Land the release PR to `main`
+9. Run `python setup.py sdist upload -r ably` to build and upload this new package to PyPi
+10. Create a tag named like `v1.2.3` and push it to GitHub - e.g. `git tag v1.2.3 && git push origin v1.2.3`
+11. Create the release on Github including populating the release notes
+
+We tend to use [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator) to collate the information required for a change log update.
+Your mileage may vary, but it seems the most reliable method to invoke the generator is something like:
+`github_changelog_generator -u ably -p ably-python --since-tag v1.0.0 --output delta.md`
+and then manually merge the delta contents in to the main change log (where `v1.0.0` in this case is the tag for the previous release).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Contributing to ably-python
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Ensure you have added suitable tests and the test suite is passing(`py.test`)
+4. Ensure you have added suitable tests and the test suite is passing (`py.test`)
 5. Push to the branch (`git push origin my-new-feature`)
 6. Create a new Pull Request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ The release process must include the following steps:
 6. Open a PR for the release against the release branch you just pushed
 7. Gain approval(s) for the release PR from maintainer(s)
 8. Land the release PR to `main`
-9. Run `python setup.py sdist upload -r ably` to build and upload this new package to PyPi
+9. From the `main` branch, run `python setup.py sdist upload -r ably` to build and upload this new package to PyPi
 10. Create a tag named like `v1.2.3` and push it to GitHub - e.g. `git tag v1.2.3 && git push origin v1.2.3`
 11. Create the release on Github including populating the release notes
 


### PR DESCRIPTION
Expands on the work undertaken in #203 to add the requirement that releases must be made via a release PR.

e.g. per [ably-java](https://github.com/ably/ably-java#release-process) and [ably-asset-tracking-android](https://github.com/ably/ably-asset-tracking-android/blob/main/CONTRIBUTING.md#release-process).