### PR TITLE
Fixes mutable-value used as argument default value

### DIFF
--- a/ably/types/capability.py
+++ b/ably/types/capability.py
@@ -7,7 +7,9 @@ log = logging.getLogger(__name__)
 
 
 class Capability(MutableMapping):
-    def __init__(self, obj={}):
+    def __init__(self, obj=None):
+        if obj is None:
+            obj = {}
         self.__dict = dict(obj)
         for k, v in obj.items():
             self[k] = v
@@ -58,7 +60,9 @@ class Capability(MutableMapping):
             self[key] = default
         return self[key]
 
-    def add_resource(self, resource, operations=[]):
+    def add_resource(self, resource, operations=None):
+        if operations is None:
+            operations = []
         if isinstance(operations, str):
             operations = [operations]
         self[resource] = list(operations)

--- a/test/ably/encoders_test.py
+++ b/test/ably/encoders_test.py
@@ -143,7 +143,9 @@ class TestTextEncodersEncryption(BaseAsyncTestCase):
         self.cipher_params = CipherParams(secret_key='keyfordecrypt_16',
                                           algorithm='aes')
 
-    def decrypt(self, payload, options={}):
+    def decrypt(self, payload, options=None):
+        if options is None:
+            options = {}
         ciphertext = base64.b64decode(payload.encode('ascii'))
         cipher = get_cipher({'key': b'keyfordecrypt_16'})
         return cipher.decrypt(ciphertext)
@@ -345,7 +347,9 @@ class TestBinaryEncodersEncryption(BaseAsyncTestCase):
     async def tearDown(self):
         await self.ably.close()
 
-    def decrypt(self, payload, options={}):
+    def decrypt(self, payload, options=None):
+        if options is None:
+            options = {}
         cipher = get_cipher({'key': b'keyfordecrypt_16'})
         return cipher.decrypt(payload)
 


### PR DESCRIPTION
Default argument values are only evaluated once at function definition time which means that modifying the default value of the argument will effect all subsequent calls of
that function.