### PR TITLE
Refine contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,20 +3,20 @@ Contributing to ably-python
 
 ## Contributing
 
-1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Ensure you have added suitable tests and the test suite is passing (`py.test`)
-5. Push to the branch (`git push origin my-new-feature`)
-6. Create a new Pull Request
+### Initialising
 
-## Test suite
+Perform the following operations after cloning the repository contents:
 
 ```shell
 git submodule init
 git submodule update
 pip install -r requirements-test.txt
-pytest test
+```
+
+### Running the test suite
+
+```shell
+python -m pytest test
 ```
 
 ## Release Process


### PR DESCRIPTION
From my experiences running tests locally before I tried to release 1.2.0 (and then hit #220).

We need to stop trying to teach people how to use Git or GitHub, hence removal of that initial list.

Locally I didn't have a `pytest` command via my ASDF installation but I could reach it via `python -m`, which seems more logical and less polluting to the operator's machine environment.