### PR TITLE
'__init__' module, fix PEP8 coding style violation

### DIFF
--- a/ably/__init__.py
+++ b/ably/__init__.py
@@ -1,10 +1,3 @@
-import logging
-
-
-logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
-
-
 from ably.rest.rest import AblyRest
 from ably.rest.auth import Auth
 from ably.rest.push import Push
@@ -14,6 +7,11 @@ from ably.types.device import DeviceDetails
 from ably.types.options import Options
 from ably.util.crypto import CipherParams
 from ably.util.exceptions import AblyException, AblyAuthException, IncompatibleClientIdException
+
+import logging
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 api_version = '1.2'
 lib_version = '1.2.0'


### PR DESCRIPTION
Addresses E402 module level import not at top of file