### PR TITLE
'TestRenewToken' fix unclosed 'AsyncClient'

### DIFF
--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -547,6 +547,8 @@ class TestRenewToken(BaseAsyncTestCase):
 
     # RSA4a
     async def test_when_not_renewable(self):
+        await self.ably.close()
+
         self.ably = await RestSetup.get_ably_rest(
             key=None,
             token='token ID cannot be used to create a new token',


### PR DESCRIPTION
This fixes warnings of the type:

```
/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/httpx/_client.py:2003: UserWarning: Unclosed <httpx.AsyncClient object at 0x7fb7003040d0>. See https://www.python-httpx.org/async/#opening-and-closing-clients for details.
  warnings.warn(
```