### PR TITLE
'TestRestChannelPublish' fix unclosed 'AsyncClient'

### DIFF
--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -334,6 +334,8 @@ class TestRestChannelPublish(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMet
         assert messages[0].client_id == some_client_id
         assert messages[1].client_id is None
 
+        await wildcard_ably.close()
+
     # TM2h
     @dont_vary_protocol
     async def test_invalid_connection_key(self):


### PR DESCRIPTION
This fixes warnings of the type:

```
/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/httpx/_client.py:2003: UserWarning: Unclosed <httpx.AsyncClient object at 0x7fb7003040d0>. See https://www.python-httpx.org/async/#opening-and-closing-clients for details.
  warnings.warn(
```
