### PR TITLE
'TestRequestToken' fix unclosed 'AsyncClient'

### DIFF
--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -337,10 +337,11 @@ class TestRequestToken(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass
         self.use_binary_protocol = use_binary_protocol
 
     async def test_with_key(self):
-        self.ably = await RestSetup.get_ably_rest(use_binary_protocol=self.use_binary_protocol)
+        ably = await RestSetup.get_ably_rest(use_binary_protocol=self.use_binary_protocol)
 
-        token_details = await self.ably.auth.request_token()
+        token_details = await ably.auth.request_token()
         assert isinstance(token_details, TokenDetails)
+        await ably.close()
 
         ably = await RestSetup.get_ably_rest(key=None, token_details=token_details,
                                              use_binary_protocol=self.use_binary_protocol)


### PR DESCRIPTION
This fixes warnings of the type:

```
/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/httpx/_client.py:2003: UserWarning: Unclosed <httpx.AsyncClient object at 0x7fb7003040d0>. See https://www.python-httpx.org/async/#opening-and-closing-clients for details.
  warnings.warn(
```