### PR TITLE
'TestRestChannelPublishIdempotent' fix unclosed 'AsyncClient'

### DIFF
--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -550,6 +550,7 @@ class TestRestChannelPublishIdempotent(BaseAsyncTestCase, metaclass=VaryByProtoc
         history = await channel.history()
         assert len(history.items) == 1
         await client.aclose()
+        await ably.close()
 
     # RSL1k5
     async def test_idempotent_client_supplied_publish(self):


### PR DESCRIPTION
Fixes warning:

```
httpx/_client.py:2003: UserWarning: Unclosed <httpx.AsyncClient object at 0x7fcb886c87f0>. See https://www.python-httpx.org/async/#opening-and-closing-clients for details.
```