### PR TITLE
'TestRestChannelPublishIdempotent' fixes missing 'await' on 'send'

### DIFF
--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -535,8 +535,8 @@ class TestRestChannelPublishIdempotent(BaseAsyncTestCase, metaclass=VaryByProtoc
         client = httpx.AsyncClient(http2=True)
         send = client.send
 
-        def side_effect(*args, **kwargs):
-            x = send(args[1])
+        async def side_effect(*args, **kwargs):
+            x = await send(args[1])
             if state['failures'] < 2:
                 state['failures'] += 1
                 raise Exception('faked exception')


### PR DESCRIPTION
This fixes the following warning:

```
test/ably/restchannelpublish_test.py::TestRestChannelPublishIdempotent::test_idempotent_library_generated_retry_bin
test/ably/restchannelpublish_test.py::TestRestChannelPublishIdempotent::test_idempotent_library_generated_retry_text
  /Users/tom.kirbygreen/dev/ably/ably-python/ably/http/http.py:202: RuntimeWarning: coroutine 'AsyncClient.send' was never awaited
    raise e
```