### PR TITLE
Respect content-type values that include a charset

### DIFF
--- a/ably/http/http.py
+++ b/ably/http/http.py
@@ -92,9 +92,9 @@ class Response:
             return None
 
         content_type = self.__response.headers.get('content-type')
-        if content_type == 'application/x-msgpack':
+        if content_type.startswith('application/x-msgpack'):
             return msgpack.unpackb(content)
-        elif content_type == 'application/json':
+        elif content_type.startswith('application/json'):
             return self.__response.json()
         else:
             raise ValueError("Unsupported content type")


### PR DESCRIPTION
When deciding how to unmarshall a response from an auth request, the logic excludes `Content-Type` values that affix a `charset` value to the end of the string (eg: `application/json; charset=utf-8`).