### PR TITLE
Use matrix python version when running pytest

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,4 +41,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=15 --statistics
     - name: Test with pytest
       run: |
-        pytest
+        python -m pytest


### PR DESCRIPTION
~~Not sure if this will actually fix the problem but I wanna see what it does in CI 👀~~ It didn't work.

My current thinking is that, since ubuntu comes with a python installation, when we run `pytest` in the github workflow it's actually using the ubuntu python rather than the one from the github setup-python action.