### PR TITLE
Drop asynctest

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -12,17 +12,17 @@ sniffio = ">=1.1"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
-doc = ["packaging", "sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
-test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "contextlib2", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
+doc = ["packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
+test = ["contextlib2", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=4)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (<0.15)", "uvloop (>=0.15)"]
 trio = ["trio (>=0.16)"]
 
 [[package]]
-name = "asynctest"
-version = "0.13.0"
-description = "Enhance the standard unittest package with features for testing asyncio libraries"
+name = "async-case"
+version = "10.1.0"
+description = "Backport of Python 3.8's unittest.async_case"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = "*"
 
 [[package]]
 name = "attrs"
@@ -33,10 +33,10 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "certifi"
@@ -55,7 +55,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "colorama"
@@ -161,8 +161,8 @@ rfc3986 = {version = ">=1.3,<2", extras = ["idna2008"]}
 sniffio = "*"
 
 [package.extras]
-brotli = ["brotlicffi", "brotli"]
-cli = ["click (>=8.0.0,<9.0.0)", "rich (>=10.0.0,<11.0.0)", "pygments (>=2.0.0,<3.0.0)"]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (>=8.0.0,<9.0.0)", "pygments (>=2.0.0,<3.0.0)", "rich (>=10.0.0,<11.0.0)"]
 http2 = ["h2 (>=3,<5)"]
 
 [[package]]
@@ -194,9 +194,9 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
+docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
 perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -235,7 +235,7 @@ pbr = ">=0.11"
 six = ">=1.7"
 
 [package.extras]
-docs = ["sphinx", "jinja2 (<2.7)", "Pygments (<2)", "sphinx (<1.3)"]
+docs = ["Pygments (<2)", "jinja2 (<2.7)", "sphinx", "sphinx (<1.3)"]
 test = ["unittest2 (>=1.1.0)"]
 
 [[package]]
@@ -285,8 +285,8 @@ python-versions = ">=3.6"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "py"
@@ -337,7 +337,7 @@ optional = false
 python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["railroad-diagrams", "jinja2"]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
@@ -373,7 +373,7 @@ pytest = ">=6.1.0"
 typing-extensions = {version = ">=3.7.2", markers = "python_version < \"3.8\""}
 
 [package.extras]
-testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)", "flaky (>=3.5.0)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
+testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
 name = "pytest-cov"
@@ -389,7 +389,7 @@ pytest = ">=4.6"
 toml = "*"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
 name = "pytest-flake8"
@@ -506,8 +506,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
 crypto = ["pycryptodome"]
@@ -516,16 +516,15 @@ oldcrypto = ["pycrypto"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "f89e97bf8246b7eb908e756dc1e88cb427ab9d6cb9b7c407af79191ee40de210"
+content-hash = "0e9010262065af6b59e72b5bbcab639e17caf9dcc2e4ee799c7f89ed5baa6646"
 
 [metadata.files]
 anyio = [
     {file = "anyio-3.6.1-py3-none-any.whl", hash = "sha256:cb29b9c70620506a9a8f87a309591713446953302d7d995344d0d7c6c0c9a7be"},
     {file = "anyio-3.6.1.tar.gz", hash = "sha256:413adf95f93886e442aea925f3ee43baa5a765a64a0f52c6081894f9992fdd0b"},
 ]
-asynctest = [
-    {file = "asynctest-0.13.0-py3-none-any.whl", hash = "sha256:5da6118a7e6d6b54d83a8f7197769d046922a44d2a99c21382f0a6e4fadae676"},
-    {file = "asynctest-0.13.0.tar.gz", hash = "sha256:c27862842d15d83e6a34eb0b2866c323880eb3a75e4485b079ea11748fd77fac"},
+async-case = [
+    {file = "async_case-10.1.0.tar.gz", hash = "sha256:b819f68c78f6c640ab1101ecf69fac189402b490901fa2abc314c48edab5d3da"},
 ]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ pytest-xdist = "^1.15"
 respx = "^0.17.1"
 importlib-metadata = "^4.12"
 pytest-asyncio = "^0.19"
+async-case = { version = "^10.1.0", python = "~3.7" }
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ pytest-cov = "^2.4"
 pytest-flake8 = "^1.1"
 pytest-xdist = "^1.15"
 respx = "^0.17.1"
-asynctest = "^0.13"
 importlib-metadata = "^4.12"
 pytest-asyncio = "^0.19"
 

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 # does not make any request, no need to vary by protocol
 class TestAuth(BaseAsyncTestCase):
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
 
     def test_auth_init_key_only(self):
@@ -161,11 +161,11 @@ class TestAuth(BaseAsyncTestCase):
 
 class TestAuthAuthorize(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
         self.test_vars = await RestSetup.get_test_vars()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def per_protocol_setup(self, use_binary_protocol):
@@ -330,7 +330,7 @@ class TestAuthAuthorize(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclas
 
 class TestRequestToken(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
 
     def per_protocol_setup(self, use_binary_protocol):
@@ -485,7 +485,7 @@ class TestRequestToken(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass
 
 class TestRenewToken(BaseAsyncTestCase):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
         self.ably = await RestSetup.get_ably_rest(use_binary_protocol=False)
         # with headers
@@ -528,7 +528,7 @@ class TestRenewToken(BaseAsyncTestCase):
         self.publish_attempt_route.side_effect = call_back
         self.mocked_api.start()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         # We need to have quiet here in order to do not have check if all endpoints were called
         self.mocked_api.stop(quiet=True)
         self.mocked_api.reset()
@@ -586,7 +586,7 @@ class TestRenewToken(BaseAsyncTestCase):
 
 class TestRenewExpiredToken(BaseAsyncTestCase):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
         self.publish_attempts = 0
         self.channel = uuid.uuid4().hex
@@ -633,7 +633,7 @@ class TestRenewExpiredToken(BaseAsyncTestCase):
         self.publish_message_route.side_effect = cb_publish
         self.mocked_api.start()
 
-    def tearDown(self):
+    async def asyncTearDown(self):
         self.mocked_api.stop(quiet=True)
         self.mocked_api.reset()
 

--- a/test/ably/restcapability_test.py
+++ b/test/ably/restcapability_test.py
@@ -9,11 +9,11 @@ from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, Ba
 
 class TestRestCapability(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
         self.ably = await RestSetup.get_ably_rest()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def per_protocol_setup(self, use_binary_protocol):

--- a/test/ably/restchannelhistory_test.py
+++ b/test/ably/restchannelhistory_test.py
@@ -13,11 +13,11 @@ log = logging.getLogger(__name__)
 
 class TestRestChannelHistory(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
         self.test_vars = await RestSetup.get_test_vars()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def per_protocol_setup(self, use_binary_protocol):

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -25,13 +25,13 @@ log = logging.getLogger(__name__)
 
 class TestRestChannelPublish(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
         self.ably = await RestSetup.get_ably_rest()
         self.client_id = uuid.uuid4().hex
         self.ably_with_client_id = await RestSetup.get_ably_rest(client_id=self.client_id, use_token_auth=True)
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
         await self.ably_with_client_id.close()
 
@@ -439,11 +439,11 @@ class TestRestChannelPublish(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMet
 
 class TestRestChannelPublishIdempotent(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
         self.ably_idempotent = await RestSetup.get_ably_rest(idempotent_rest_publishing=True)
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
         await self.ably_idempotent.close()
 

--- a/test/ably/restchannels_test.py
+++ b/test/ably/restchannels_test.py
@@ -13,11 +13,11 @@ from test.ably.utils import BaseAsyncTestCase
 # makes no request, no need to use different protocols
 class TestChannels(BaseAsyncTestCase):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
         self.ably = await RestSetup.get_ably_rest()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def test_rest_channels_attr(self):

--- a/test/ably/restcrypto_test.py
+++ b/test/ably/restcrypto_test.py
@@ -19,12 +19,12 @@ log = logging.getLogger(__name__)
 
 class TestRestCrypto(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
         self.ably = await RestSetup.get_ably_rest()
         self.ably2 = await RestSetup.get_ably_rest()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
         await self.ably2.close()
 

--- a/test/ably/restinit_test.py
+++ b/test/ably/restinit_test.py
@@ -14,7 +14,7 @@ from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, Ba
 
 class TestRestInit(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
 
     @dont_vary_protocol

--- a/test/ably/restpaginatedresult_test.py
+++ b/test/ably/restpaginatedresult_test.py
@@ -27,7 +27,7 @@ class TestPaginatedResult(BaseAsyncTestCase):
 
         return callback
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest(use_binary_protocol=False)
         # Mocked responses
         # without specific headers
@@ -62,7 +62,7 @@ class TestPaginatedResult(BaseAsyncTestCase):
             url='http://rest.ably.io/channels/channel_name/ch2',
             response_processor=lambda response: response.to_native())
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         self.mocked_api.stop()
         self.mocked_api.reset()
         await self.ably.close()

--- a/test/ably/restpresence_test.py
+++ b/test/ably/restpresence_test.py
@@ -12,13 +12,13 @@ from test.ably.restsetup import RestSetup
 
 class TestPresence(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
         self.ably = await RestSetup.get_ably_rest()
         self.channel = self.ably.channels.get('persisted:presence_fixtures')
         self.ably.options.use_binary_protocol = True
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         self.ably.channels.release('persisted:presence_fixtures')
         await self.ably.close()
 
@@ -189,12 +189,12 @@ class TestPresence(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
 class TestPresenceCrypt(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
         key = b'0123456789abcdef'
         self.channel = self.ably.channels.get('persisted:presence_fixtures', cipher={'key': key})
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         self.ably.channels.release('persisted:presence_fixtures')
         await self.ably.close()
 

--- a/test/ably/restpush_test.py
+++ b/test/ably/restpush_test.py
@@ -19,7 +19,7 @@ DEVICE_TOKEN = '740f4707bebcf74f9b7c25d48e3358945f6aa01da5ddb387462c7eaf61bb78ad
 
 class TestPush(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
 
         # Register several devices for later use
@@ -34,7 +34,7 @@ class TestPush(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
             await self.save_subscription(channel, device_id=device.id)
         assert len(list(itertools.chain(*self.channels.values()))) == len(self.devices)
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         for key, channel in zip(self.devices, itertools.cycle(self.channels)):
             device = self.devices[key]
             await self.remove_subscription(channel, device_id=device.id)

--- a/test/ably/reststats_test.py
+++ b/test/ably/reststats_test.py
@@ -25,7 +25,7 @@ class TestRestAppStatsSetup:
             'limit': 1
         }
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
         self.ably_text = await RestSetup.get_ably_rest(use_binary_protocol=False)
 
@@ -74,7 +74,7 @@ class TestRestAppStatsSetup:
         await self.ably.http.post('/stats', body=stats + previous_stats)
         TestRestAppStatsSetup.__stats_added = True
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
         await self.ably_text.close()
 

--- a/test/ably/resttoken_test.py
+++ b/test/ably/resttoken_test.py
@@ -22,12 +22,12 @@ class TestRestToken(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
     async def server_time(self):
         return await self.ably.time()
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         capability = {"*": ["*"]}
         self.permit_all = str(Capability(capability))
         self.ably = await RestSetup.get_ably_rest()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def per_protocol_setup(self, use_binary_protocol):
@@ -160,12 +160,12 @@ class TestRestToken(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
 class TestCreateTokenRequest(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
         self.key_name = self.ably.options.key_name
         self.key_secret = self.ably.options.key_secret
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def per_protocol_setup(self, use_binary_protocol):

--- a/test/ably/utils.py
+++ b/test/ably/utils.py
@@ -2,8 +2,12 @@ import functools
 import random
 import string
 import unittest
+import sys
+if sys.version_info >= (3, 8):
+    from unittest import IsolatedAsyncioTestCase
+else:
+    from async_case import IsolatedAsyncioTestCase
 
-import asynctest
 import msgpack
 import mock
 import respx
@@ -35,7 +39,7 @@ class BaseTestCase(unittest.TestCase):
         return cls.ably.channels.get(name)
 
 
-class BaseAsyncTestCase(asynctest.TestCase):
+class BaseAsyncTestCase(IsolatedAsyncioTestCase):
 
     def respx_add_empty_msg_pack(self, url, method='GET'):
         respx.route(method=method, url=url).return_value = Response(


### PR DESCRIPTION
Updated tests to use `IsolatedAsyncioTestCase` instead of deprecated `asynctest.TestCase`.
Since we support Python 3.7 and `IsolatedAsyncioTestCase` was added to stdlib in Python 3.8, a backport package was introduced that fills in the missing definition.