### PR TITLE
Ignore several cases of DeprecatedWarning, fix RuntimeWarning

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -224,19 +224,16 @@ python-versions = "*"
 
 [[package]]
 name = "mock"
-version = "1.3.0"
+version = "4.0.3"
 description = "Rolling backport of unittest.mock for all Pythons"
 category = "dev"
 optional = false
-python-versions = "*"
-
-[package.dependencies]
-pbr = ">=0.11"
-six = ">=1.7"
+python-versions = ">=3.6"
 
 [package.extras]
-docs = ["Pygments (<2)", "jinja2 (<2.7)", "sphinx", "sphinx (<1.3)"]
-test = ["unittest2 (>=1.1.0)"]
+build = ["blurb", "twine", "wheel"]
+docs = ["sphinx"]
+test = ["pytest (<5.4)", "pytest-cov"]
 
 [[package]]
 name = "msgpack"
@@ -256,14 +253,6 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
-
-[[package]]
-name = "pbr"
-version = "5.10.0"
-description = "Python Build Reasonableness"
-category = "dev"
-optional = false
-python-versions = ">=2.6"
 
 [[package]]
 name = "pep8-naming"
@@ -516,7 +505,7 @@ oldcrypto = ["pycrypto"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "0e9010262065af6b59e72b5bbcab639e17caf9dcc2e4ee799c7f89ed5baa6646"
+content-hash = "903aabc0c06fdb0cf85096138c06519225b8b02204abf122dbf13041f347ed56"
 
 [metadata.files]
 anyio = [
@@ -647,8 +636,8 @@ methoddispatch = [
     {file = "methoddispatch-3.0.2.tar.gz", hash = "sha256:dc2c5101c5634fd9e9f86449e30515780d8583d1472e70ad826abb28d9ddd1a7"},
 ]
 mock = [
-    {file = "mock-1.3.0-py2.py3-none-any.whl", hash = "sha256:3f573a18be94de886d1191f27c168427ef693e8dcfcecf95b170577b2eb69cbb"},
-    {file = "mock-1.3.0.tar.gz", hash = "sha256:1e247dbecc6ce057299eb7ee019ad68314bb93152e81d9a6110d35f4d5eca0f6"},
+    {file = "mock-4.0.3-py3-none-any.whl", hash = "sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62"},
+    {file = "mock-4.0.3.tar.gz", hash = "sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc"},
 ]
 msgpack = [
     {file = "msgpack-1.0.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4ab251d229d10498e9a2f3b1e68ef64cb393394ec477e3370c457f9430ce9250"},
@@ -707,10 +696,6 @@ msgpack = [
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
-]
-pbr = [
-    {file = "pbr-5.10.0-py2.py3-none-any.whl", hash = "sha256:da3e18aac0a3c003e9eea1a81bd23e5a3a75d745670dcf736317b7d966887fdf"},
-    {file = "pbr-5.10.0.tar.gz", hash = "sha256:cfcc4ff8e698256fc17ea3ff796478b050852585aa5bae79ecd05b2ab7b39b9a"},
 ]
 pep8-naming = [
     {file = "pep8-naming-0.4.1.tar.gz", hash = "sha256:4eedfd4c4b05e48796f74f5d8628c068ff788b9c2b08471ad408007fc6450e5a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ crypto = ["pycryptodome"]
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1"
-mock = "^1.3"
+mock = "^4.0.3"
 pep8-naming = "^0.4.1"
 pytest-cov = "^2.4"
 pytest-flake8 = "^1.1"

--- a/test/ably/encoders_test.py
+++ b/test/ably/encoders_test.py
@@ -10,8 +10,7 @@ from ably import CipherParams
 from ably.util.crypto import get_cipher
 from ably.types.message import Message
 
-from test.ably.utils import AsyncMock
-
+from unittest.mock import AsyncMock
 
 log = logging.getLogger(__name__)
 

--- a/test/ably/encoders_test.py
+++ b/test/ably/encoders_test.py
@@ -10,7 +10,10 @@ from ably import CipherParams
 from ably.util.crypto import get_cipher
 from ably.types.message import Message
 
-from unittest.mock import AsyncMock
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    from mock import AsyncMock
 
 log = logging.getLogger(__name__)
 

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -202,6 +202,7 @@ class TestAuthAuthorize(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclas
         assert isinstance(token, TokenDetails)
 
     @dont_vary_protocol
+    @pytest.mark.filterwarnings('ignore::RuntimeWarning')
     async def test_authorize_adheres_to_request_token(self):
         token_params = {'ttl': 10, 'client_id': 'client_id'}
         auth_params = {'auth_url': 'somewhere.com', 'query_time': True}

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -17,7 +17,8 @@ from ably import AblyAuthException
 from ably.types.tokendetails import TokenDetails
 
 from test.ably.restsetup import RestSetup
-from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, BaseAsyncTestCase, AsyncMock
+from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, BaseAsyncTestCase
+from unittest.mock import AsyncMock
 
 log = logging.getLogger(__name__)
 
@@ -202,7 +203,6 @@ class TestAuthAuthorize(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclas
         assert isinstance(token, TokenDetails)
 
     @dont_vary_protocol
-    @pytest.mark.filterwarnings('ignore::RuntimeWarning')
     async def test_authorize_adheres_to_request_token(self):
         token_params = {'ttl': 10, 'client_id': 'client_id'}
         auth_params = {'auth_url': 'somewhere.com', 'query_time': True}

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -18,7 +18,10 @@ from ably.types.tokendetails import TokenDetails
 
 from test.ably.restsetup import RestSetup
 from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, BaseAsyncTestCase
-from unittest.mock import AsyncMock
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    from mock import AsyncMock
 
 log = logging.getLogger(__name__)
 

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -23,6 +23,7 @@ from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, Ba
 log = logging.getLogger(__name__)
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 class TestRestChannelPublish(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
     async def asyncSetUp(self):

--- a/test/ably/resthttp_test.py
+++ b/test/ably/resthttp_test.py
@@ -111,11 +111,11 @@ class TestRestHttp(BaseAsyncTestCase):
         client = httpx.AsyncClient(http2=True)
         send = client.send
 
-        def side_effect(*args, **kwargs):
+        async def side_effect(*args, **kwargs):
             if args[1].url.host == host:
                 state['errors'] += 1
                 raise RuntimeError
-            return send(args[1])
+            return await send(args[1])
 
         with mock.patch('httpx.AsyncClient.send', side_effect=side_effect, autospec=True):
             # The main host is called and there's an error

--- a/test/ably/resthttp_test.py
+++ b/test/ably/resthttp_test.py
@@ -101,6 +101,7 @@ class TestRestHttp(BaseAsyncTestCase):
         await ably.close()
 
     # RSC15f
+    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     async def test_cached_fallback(self):
         timeout = 2000
         ably = await RestSetup.get_ably_rest(fallback_hosts_use_default=True, fallback_retry_timeout=timeout)

--- a/test/ably/restinit_test.py
+++ b/test/ably/restinit_test.py
@@ -91,6 +91,7 @@ class TestRestInit(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
     # RSC15
     @dont_vary_protocol
+    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     def test_fallback_hosts(self):
         # Specify the fallback_hosts (RSC15a)
         fallback_hosts = [

--- a/test/ably/restrequest_test.py
+++ b/test/ably/restrequest_test.py
@@ -96,6 +96,7 @@ async def test_headers(rest):
 
 # RSC19e
 @pytest.mark.asyncio
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 async def test_timeout(test_vars):
     # Timeout
     timeout = 0.000001

--- a/test/ably/utils.py
+++ b/test/ably/utils.py
@@ -170,8 +170,3 @@ def new_dict(src, **kw):
 
 def get_random_key(d):
     return random.choice(list(d))
-
-
-class AsyncMock(mock.MagicMock):
-    async def __call__(self, *args, **kwargs):
-        return super(AsyncMock, self).__call__(*args, **kwargs)


### PR DESCRIPTION
- Added filter for several `DeprecatedWarning` instances in tests where the warning is occurring within Ably Python SDK.
- Fixed a `RuntimeWarning` in `test_cached_fallback` by updating `mock` to `4.0.3` and importing `AsyncMock` from either `unittest.mock` (Python 3.8+) or `mock` (Python 3.7)