### PR TITLE
Fix test deprecation warnings

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -12,8 +12,8 @@ sniffio = ">=1.1"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
-doc = ["packaging", "sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
-test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "contextlib2", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
+doc = ["packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
+test = ["contextlib2", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=4)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (<0.15)", "uvloop (>=0.15)"]
 trio = ["trio (>=0.16)"]
 
 [[package]]
@@ -33,10 +33,10 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "certifi"
@@ -55,7 +55,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "colorama"
@@ -161,8 +161,8 @@ rfc3986 = {version = ">=1.3,<2", extras = ["idna2008"]}
 sniffio = "*"
 
 [package.extras]
-brotli = ["brotlicffi", "brotli"]
-cli = ["click (>=8.0.0,<9.0.0)", "rich (>=10.0.0,<11.0.0)", "pygments (>=2.0.0,<3.0.0)"]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (>=8.0.0,<9.0.0)", "pygments (>=2.0.0,<3.0.0)", "rich (>=10.0.0,<11.0.0)"]
 http2 = ["h2 (>=3,<5)"]
 
 [[package]]
@@ -194,9 +194,9 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
+docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
 perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -224,19 +224,16 @@ python-versions = "*"
 
 [[package]]
 name = "mock"
-version = "1.3.0"
+version = "4.0.3"
 description = "Rolling backport of unittest.mock for all Pythons"
 category = "dev"
 optional = false
-python-versions = "*"
-
-[package.dependencies]
-pbr = ">=0.11"
-six = ">=1.7"
+python-versions = ">=3.6"
 
 [package.extras]
-docs = ["sphinx", "jinja2 (<2.7)", "Pygments (<2)", "sphinx (<1.3)"]
-test = ["unittest2 (>=1.1.0)"]
+build = ["blurb", "twine", "wheel"]
+docs = ["sphinx"]
+test = ["pytest (<5.4)", "pytest-cov"]
 
 [[package]]
 name = "msgpack"
@@ -258,14 +255,6 @@ python-versions = ">=3.6"
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
-name = "pbr"
-version = "5.10.0"
-description = "Python Build Reasonableness"
-category = "dev"
-optional = false
-python-versions = ">=2.6"
-
-[[package]]
 name = "pep8-naming"
 version = "0.4.1"
 description = "Check PEP-8 naming conventions, plugin for flake8"
@@ -285,8 +274,8 @@ python-versions = ">=3.6"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "py"
@@ -337,7 +326,7 @@ optional = false
 python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["railroad-diagrams", "jinja2"]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
@@ -374,7 +363,7 @@ pytest = ">=4.6"
 toml = "*"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
 name = "pytest-flake8"
@@ -491,8 +480,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
 crypto = ["pycryptodome"]
@@ -501,7 +490,7 @@ oldcrypto = ["pycrypto"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "0f5fa1c07bd116047635d4d34692f7f9ca1bb194988445ef61854469c2ce214d"
+content-hash = "669edb5b0c1ed2d51627f054aa8fd4315652d56694dce8e9131ed3897efd4f4c"
 
 [metadata.files]
 anyio = [
@@ -633,8 +622,8 @@ methoddispatch = [
     {file = "methoddispatch-3.0.2.tar.gz", hash = "sha256:dc2c5101c5634fd9e9f86449e30515780d8583d1472e70ad826abb28d9ddd1a7"},
 ]
 mock = [
-    {file = "mock-1.3.0-py2.py3-none-any.whl", hash = "sha256:3f573a18be94de886d1191f27c168427ef693e8dcfcecf95b170577b2eb69cbb"},
-    {file = "mock-1.3.0.tar.gz", hash = "sha256:1e247dbecc6ce057299eb7ee019ad68314bb93152e81d9a6110d35f4d5eca0f6"},
+    {file = "mock-4.0.3-py3-none-any.whl", hash = "sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62"},
+    {file = "mock-4.0.3.tar.gz", hash = "sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc"},
 ]
 msgpack = [
     {file = "msgpack-1.0.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4ab251d229d10498e9a2f3b1e68ef64cb393394ec477e3370c457f9430ce9250"},
@@ -693,10 +682,6 @@ msgpack = [
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
-]
-pbr = [
-    {file = "pbr-5.10.0-py2.py3-none-any.whl", hash = "sha256:da3e18aac0a3c003e9eea1a81bd23e5a3a75d745670dcf736317b7d966887fdf"},
-    {file = "pbr-5.10.0.tar.gz", hash = "sha256:cfcc4ff8e698256fc17ea3ff796478b050852585aa5bae79ecd05b2ab7b39b9a"},
 ]
 pep8-naming = [
     {file = "pep8-naming-0.4.1.tar.gz", hash = "sha256:4eedfd4c4b05e48796f74f5d8628c068ff788b9c2b08471ad408007fc6450e5a"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -17,12 +17,12 @@ test = ["contextlib2", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=
 trio = ["trio (>=0.16)"]
 
 [[package]]
-name = "asynctest"
-version = "0.13.0"
-description = "Enhance the standard unittest package with features for testing asyncio libraries"
+name = "async-case"
+version = "10.1.0"
+description = "Backport of Python 3.8's unittest.async_case"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = "*"
 
 [[package]]
 name = "attrs"
@@ -501,16 +501,15 @@ oldcrypto = ["pycrypto"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "669edb5b0c1ed2d51627f054aa8fd4315652d56694dce8e9131ed3897efd4f4c"
+content-hash = "5e0223b30434d511c3c18b6562dc63c33d9b96443a82cf280cf2ee44f64e9f8b"
 
 [metadata.files]
 anyio = [
     {file = "anyio-3.6.1-py3-none-any.whl", hash = "sha256:cb29b9c70620506a9a8f87a309591713446953302d7d995344d0d7c6c0c9a7be"},
     {file = "anyio-3.6.1.tar.gz", hash = "sha256:413adf95f93886e442aea925f3ee43baa5a765a64a0f52c6081894f9992fdd0b"},
 ]
-asynctest = [
-    {file = "asynctest-0.13.0-py3-none-any.whl", hash = "sha256:5da6118a7e6d6b54d83a8f7197769d046922a44d2a99c21382f0a6e4fadae676"},
-    {file = "asynctest-0.13.0.tar.gz", hash = "sha256:c27862842d15d83e6a34eb0b2866c323880eb3a75e4485b079ea11748fd77fac"},
+async-case = [
+    {file = "async_case-10.1.0.tar.gz", hash = "sha256:b819f68c78f6c640ab1101ecf69fac189402b490901fa2abc314c48edab5d3da"},
 ]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ pytest-cov = "^2.4"
 pytest-flake8 = "^1.1"
 pytest-xdist = "^1.15"
 respx = "^0.17.1"
-asynctest = "^0.13"
 importlib-metadata = "^4.12"
 pytest-timeout = "^2.1.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ crypto = ["pycryptodome"]
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1"
-mock = "^1.3"
+mock = "^4.0.3"
 pep8-naming = "^0.4.1"
 pytest-cov = "^2.4"
 pytest-flake8 = "^1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ pytest-xdist = "^1.15"
 respx = "^0.17.1"
 importlib-metadata = "^4.12"
 pytest-timeout = "^2.1.0"
+async-case = { version = "^10.1.0", python = "~3.7" }
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/test/ably/encoders_test.py
+++ b/test/ably/encoders_test.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import logging
+import sys
 
 import mock
 import msgpack
@@ -11,9 +12,10 @@ from ably.types.message import Message
 
 from test.ably.restsetup import RestSetup
 from test.ably.utils import BaseAsyncTestCase
-try:
+
+if sys.version_info >= (3, 8):
     from unittest.mock import AsyncMock
-except ImportError:
+else:
     from mock import AsyncMock
 
 log = logging.getLogger(__name__)

--- a/test/ably/encoders_test.py
+++ b/test/ably/encoders_test.py
@@ -11,7 +11,10 @@ from ably.types.message import Message
 
 from test.ably.restsetup import RestSetup
 from test.ably.utils import BaseAsyncTestCase
-from unittest.mock import AsyncMock
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    from mock import AsyncMock
 
 log = logging.getLogger(__name__)
 

--- a/test/ably/encoders_test.py
+++ b/test/ably/encoders_test.py
@@ -22,10 +22,10 @@ log = logging.getLogger(__name__)
 
 
 class TestTextEncodersNoEncryption(BaseAsyncTestCase):
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest(use_binary_protocol=False)
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     async def test_text_utf8(self):
@@ -144,12 +144,12 @@ class TestTextEncodersNoEncryption(BaseAsyncTestCase):
 
 
 class TestTextEncodersEncryption(BaseAsyncTestCase):
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest(use_binary_protocol=False)
         self.cipher_params = CipherParams(secret_key='keyfordecrypt_16',
                                           algorithm='aes')
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def decrypt(self, payload, options=None):
@@ -258,10 +258,10 @@ class TestTextEncodersEncryption(BaseAsyncTestCase):
 
 class TestBinaryEncodersNoEncryption(BaseAsyncTestCase):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def decode(self, data):
@@ -349,11 +349,11 @@ class TestBinaryEncodersNoEncryption(BaseAsyncTestCase):
 
 class TestBinaryEncodersEncryption(BaseAsyncTestCase):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
         self.cipher_params = CipherParams(secret_key='keyfordecrypt_16', algorithm='aes')
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def decrypt(self, payload, options=None):

--- a/test/ably/encoders_test.py
+++ b/test/ably/encoders_test.py
@@ -10,7 +10,8 @@ from ably.util.crypto import get_cipher
 from ably.types.message import Message
 
 from test.ably.restsetup import RestSetup
-from test.ably.utils import BaseAsyncTestCase, AsyncMock
+from test.ably.utils import BaseAsyncTestCase
+from unittest.mock import AsyncMock
 
 log = logging.getLogger(__name__)
 

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -30,7 +30,7 @@ log = logging.getLogger(__name__)
 
 # does not make any request, no need to vary by protocol
 class TestAuth(BaseAsyncTestCase):
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
 
     def test_auth_init_key_only(self):
@@ -167,11 +167,11 @@ class TestAuth(BaseAsyncTestCase):
 
 class TestAuthAuthorize(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
         self.test_vars = await RestSetup.get_test_vars()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def per_protocol_setup(self, use_binary_protocol):
@@ -336,7 +336,7 @@ class TestAuthAuthorize(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclas
 
 class TestRequestToken(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
 
     def per_protocol_setup(self, use_binary_protocol):
@@ -491,7 +491,7 @@ class TestRequestToken(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass
 
 class TestRenewToken(BaseAsyncTestCase):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
         self.ably = await RestSetup.get_ably_rest(use_binary_protocol=False)
         # with headers
@@ -534,7 +534,7 @@ class TestRenewToken(BaseAsyncTestCase):
         self.publish_attempt_route.side_effect = call_back
         self.mocked_api.start()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         # We need to have quiet here in order to do not have check if all endpoints were called
         self.mocked_api.stop(quiet=True)
         self.mocked_api.reset()
@@ -592,7 +592,7 @@ class TestRenewToken(BaseAsyncTestCase):
 
 class TestRenewExpiredToken(BaseAsyncTestCase):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
         self.publish_attempts = 0
         self.channel = uuid.uuid4().hex
@@ -639,7 +639,7 @@ class TestRenewExpiredToken(BaseAsyncTestCase):
         self.publish_message_route.side_effect = cb_publish
         self.mocked_api.start()
 
-    def tearDown(self):
+    async def asyncTearDown(self):
         self.mocked_api.stop(quiet=True)
         self.mocked_api.reset()
 

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -18,7 +18,10 @@ from ably.types.tokendetails import TokenDetails
 
 from test.ably.restsetup import RestSetup
 from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, BaseAsyncTestCase
-from unittest.mock import AsyncMock
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    from mock import AsyncMock
 
 log = logging.getLogger(__name__)
 

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import time
 import uuid
 import base64
@@ -18,9 +19,10 @@ from ably.types.tokendetails import TokenDetails
 
 from test.ably.restsetup import RestSetup
 from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, BaseAsyncTestCase
-try:
+
+if sys.version_info >= (3, 8):
     from unittest.mock import AsyncMock
-except ImportError:
+else:
     from mock import AsyncMock
 
 log = logging.getLogger(__name__)

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -17,7 +17,8 @@ from ably import AblyAuthException
 from ably.types.tokendetails import TokenDetails
 
 from test.ably.restsetup import RestSetup
-from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, BaseAsyncTestCase, AsyncMock
+from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, BaseAsyncTestCase
+from unittest.mock import AsyncMock
 
 log = logging.getLogger(__name__)
 

--- a/test/ably/restcapability_test.py
+++ b/test/ably/restcapability_test.py
@@ -9,11 +9,11 @@ from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, Ba
 
 class TestRestCapability(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
         self.ably = await RestSetup.get_ably_rest()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def per_protocol_setup(self, use_binary_protocol):

--- a/test/ably/restchannelhistory_test.py
+++ b/test/ably/restchannelhistory_test.py
@@ -13,11 +13,11 @@ log = logging.getLogger(__name__)
 
 class TestRestChannelHistory(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
         self.test_vars = await RestSetup.get_test_vars()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def per_protocol_setup(self, use_binary_protocol):

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -27,13 +27,13 @@ log = logging.getLogger(__name__)
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
 class TestRestChannelPublish(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
         self.ably = await RestSetup.get_ably_rest()
         self.client_id = uuid.uuid4().hex
         self.ably_with_client_id = await RestSetup.get_ably_rest(client_id=self.client_id, use_token_auth=True)
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
         await self.ably_with_client_id.close()
 
@@ -441,11 +441,11 @@ class TestRestChannelPublish(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMet
 
 class TestRestChannelPublishIdempotent(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
         self.ably_idempotent = await RestSetup.get_ably_rest(idempotent_rest_publishing=True)
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
         await self.ably_idempotent.close()
 

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -23,6 +23,7 @@ from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, Ba
 log = logging.getLogger(__name__)
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 class TestRestChannelPublish(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
     async def setUp(self):

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -23,6 +23,7 @@ from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, Ba
 log = logging.getLogger(__name__)
 
 
+# Ignore library warning regarding client_id
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
 class TestRestChannelPublish(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 

--- a/test/ably/restchannels_test.py
+++ b/test/ably/restchannels_test.py
@@ -13,11 +13,11 @@ from test.ably.utils import BaseAsyncTestCase
 # makes no request, no need to use different protocols
 class TestChannels(BaseAsyncTestCase):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
         self.ably = await RestSetup.get_ably_rest()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def test_rest_channels_attr(self):

--- a/test/ably/restchannelstatus_test.py
+++ b/test/ably/restchannelstatus_test.py
@@ -8,10 +8,10 @@ log = logging.getLogger(__name__)
 
 class TestRestChannelStatus(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def per_protocol_setup(self, use_binary_protocol):

--- a/test/ably/restcrypto_test.py
+++ b/test/ably/restcrypto_test.py
@@ -19,12 +19,12 @@ log = logging.getLogger(__name__)
 
 class TestRestCrypto(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
         self.ably = await RestSetup.get_ably_rest()
         self.ably2 = await RestSetup.get_ably_rest()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
         await self.ably2.close()
 

--- a/test/ably/resthttp_test.py
+++ b/test/ably/resthttp_test.py
@@ -101,6 +101,7 @@ class TestRestHttp(BaseAsyncTestCase):
         await ably.close()
 
     # RSC15f
+    # Ignore library warning regarding fallback_hosts_use_default
     @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     async def test_cached_fallback(self):
         timeout = 2000

--- a/test/ably/resthttp_test.py
+++ b/test/ably/resthttp_test.py
@@ -111,11 +111,11 @@ class TestRestHttp(BaseAsyncTestCase):
         client = httpx.AsyncClient(http2=True)
         send = client.send
 
-        def side_effect(*args, **kwargs):
+        async def side_effect(*args, **kwargs):
             if args[1].url.host == host:
                 state['errors'] += 1
                 raise RuntimeError
-            return send(args[1])
+            return await send(args[1])
 
         with mock.patch('httpx.AsyncClient.send', side_effect=side_effect, autospec=True):
             # The main host is called and there's an error

--- a/test/ably/resthttp_test.py
+++ b/test/ably/resthttp_test.py
@@ -101,6 +101,7 @@ class TestRestHttp(BaseAsyncTestCase):
         await ably.close()
 
     # RSC15f
+    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     async def test_cached_fallback(self):
         timeout = 2000
         ably = await RestSetup.get_ably_rest(fallback_hosts_use_default=True, fallback_retry_timeout=timeout)

--- a/test/ably/restinit_test.py
+++ b/test/ably/restinit_test.py
@@ -91,6 +91,7 @@ class TestRestInit(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
     # RSC15
     @dont_vary_protocol
+    # Ignore library warning regarding fallback_hosts_use_default
     @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     def test_fallback_hosts(self):
         # Specify the fallback_hosts (RSC15a)

--- a/test/ably/restinit_test.py
+++ b/test/ably/restinit_test.py
@@ -14,7 +14,7 @@ from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol, Ba
 
 class TestRestInit(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
 
     @dont_vary_protocol

--- a/test/ably/restinit_test.py
+++ b/test/ably/restinit_test.py
@@ -91,6 +91,7 @@ class TestRestInit(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
     # RSC15
     @dont_vary_protocol
+    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     def test_fallback_hosts(self):
         # Specify the fallback_hosts (RSC15a)
         fallback_hosts = [

--- a/test/ably/restpaginatedresult_test.py
+++ b/test/ably/restpaginatedresult_test.py
@@ -27,7 +27,7 @@ class TestPaginatedResult(BaseAsyncTestCase):
 
         return callback
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest(use_binary_protocol=False)
         # Mocked responses
         # without specific headers
@@ -62,7 +62,7 @@ class TestPaginatedResult(BaseAsyncTestCase):
             url='http://rest.ably.io/channels/channel_name/ch2',
             response_processor=lambda response: response.to_native())
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         self.mocked_api.stop()
         self.mocked_api.reset()
         await self.ably.close()

--- a/test/ably/restpresence_test.py
+++ b/test/ably/restpresence_test.py
@@ -12,13 +12,13 @@ from test.ably.restsetup import RestSetup
 
 class TestPresence(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.test_vars = await RestSetup.get_test_vars()
         self.ably = await RestSetup.get_ably_rest()
         self.channel = self.ably.channels.get('persisted:presence_fixtures')
         self.ably.options.use_binary_protocol = True
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         self.ably.channels.release('persisted:presence_fixtures')
         await self.ably.close()
 
@@ -189,12 +189,12 @@ class TestPresence(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
 class TestPresenceCrypt(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
         key = b'0123456789abcdef'
         self.channel = self.ably.channels.get('persisted:presence_fixtures', cipher={'key': key})
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         self.ably.channels.release('persisted:presence_fixtures')
         await self.ably.close()
 

--- a/test/ably/restpush_test.py
+++ b/test/ably/restpush_test.py
@@ -19,7 +19,7 @@ DEVICE_TOKEN = '740f4707bebcf74f9b7c25d48e3358945f6aa01da5ddb387462c7eaf61bb78ad
 
 class TestPush(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
 
         # Register several devices for later use
@@ -34,7 +34,7 @@ class TestPush(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
             await self.save_subscription(channel, device_id=device.id)
         assert len(list(itertools.chain(*self.channels.values()))) == len(self.devices)
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         for key, channel in zip(self.devices, itertools.cycle(self.channels)):
             device = self.devices[key]
             await self.remove_subscription(channel, device_id=device.id)

--- a/test/ably/restrequest_test.py
+++ b/test/ably/restrequest_test.py
@@ -90,6 +90,7 @@ class TestRestRequest(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass)
 
     # RSC19e
     @dont_vary_protocol
+    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     async def test_timeout(self):
         # Timeout
         timeout = 0.000001

--- a/test/ably/restrequest_test.py
+++ b/test/ably/restrequest_test.py
@@ -90,6 +90,7 @@ class TestRestRequest(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass)
 
     # RSC19e
     @dont_vary_protocol
+    # Ignore library warning regarding fallback_hosts_use_default
     @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     async def test_timeout(self):
         # Timeout

--- a/test/ably/restrequest_test.py
+++ b/test/ably/restrequest_test.py
@@ -11,7 +11,7 @@ from test.ably.utils import VaryByProtocolTestsMetaclass, dont_vary_protocol
 # RSC19
 class TestRestRequest(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
         self.test_vars = await RestSetup.get_test_vars()
 
@@ -22,7 +22,7 @@ class TestRestRequest(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass)
             body = {'name': 'event%s' % i, 'data': 'lorem ipsum %s' % i}
             await self.ably.request('POST', self.path, body=body)
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def per_protocol_setup(self, use_binary_protocol):

--- a/test/ably/reststats_test.py
+++ b/test/ably/reststats_test.py
@@ -25,7 +25,7 @@ class TestRestAppStatsSetup:
             'limit': 1
         }
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
         self.ably_text = await RestSetup.get_ably_rest(use_binary_protocol=False)
 
@@ -74,7 +74,7 @@ class TestRestAppStatsSetup:
         await self.ably.http.post('/stats', body=stats + previous_stats)
         TestRestAppStatsSetup.__stats_added = True
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
         await self.ably_text.close()
 

--- a/test/ably/resttime_test.py
+++ b/test/ably/resttime_test.py
@@ -14,10 +14,10 @@ class TestRestTime(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
         self.ably.options.use_binary_protocol = use_binary_protocol
         self.use_binary_protocol = use_binary_protocol
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     async def test_time_accuracy(self):

--- a/test/ably/resttoken_test.py
+++ b/test/ably/resttoken_test.py
@@ -22,12 +22,12 @@ class TestRestToken(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
     async def server_time(self):
         return await self.ably.time()
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         capability = {"*": ["*"]}
         self.permit_all = str(Capability(capability))
         self.ably = await RestSetup.get_ably_rest()
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def per_protocol_setup(self, use_binary_protocol):
@@ -160,12 +160,12 @@ class TestRestToken(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
 class TestCreateTokenRequest(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass):
 
-    async def setUp(self):
+    async def asyncSetUp(self):
         self.ably = await RestSetup.get_ably_rest()
         self.key_name = self.ably.options.key_name
         self.key_secret = self.ably.options.key_secret
 
-    async def tearDown(self):
+    async def asyncTearDown(self):
         await self.ably.close()
 
     def per_protocol_setup(self, use_binary_protocol):

--- a/test/ably/utils.py
+++ b/test/ably/utils.py
@@ -162,8 +162,3 @@ def new_dict(src, **kw):
 
 def get_random_key(d):
     return random.choice(list(d))
-
-
-class AsyncMock(mock.MagicMock):
-    async def __call__(self, *args, **kwargs):
-        return super(AsyncMock, self).__call__(*args, **kwargs)

--- a/test/ably/utils.py
+++ b/test/ably/utils.py
@@ -2,8 +2,12 @@ import functools
 import random
 import string
 import unittest
+import sys
+if sys.version_info >= (3, 8):
+    from unittest import IsolatedAsyncioTestCase
+else:
+    from async_case import IsolatedAsyncioTestCase
 
-import asynctest
 import msgpack
 import mock
 import respx
@@ -31,7 +35,7 @@ class BaseTestCase(unittest.TestCase):
         return cls.ably.channels.get(name)
 
 
-class BaseAsyncTestCase(asynctest.TestCase):
+class BaseAsyncTestCase(IsolatedAsyncioTestCase):
 
     def respx_add_empty_msg_pack(self, url, method='GET'):
         respx.route(method=method, url=url).return_value = Response(


### PR DESCRIPTION
- Drop internally-defined `AsyncMock` class, replace it with `AsyncMock` from `unittest.mock` (Python 3.8+) or  `mock` (Python 3.7)
- Bump `mock` dev dependency from 1.3.0 to 4.0.3, needed for Python 3.7 tests to pass after switching to using `AsyncMock` from `mock`
- Ignore several cases of `DeprecatedWarning` where the warning originated from within `ably-python` SDK
- Fix test error in `test_cached_fallback` after upgrading to `mock` 4.0.3 related to never awaited `AsyncClient.send` call.