### PR TITLE
Realtime extends rest

### DIFF
--- a/ably/realtime/realtime.py
+++ b/ably/realtime/realtime.py
@@ -2,6 +2,7 @@ import logging
 import asyncio
 from ably.realtime.connection import Connection
 from ably.rest.auth import Auth
+from ably.rest.rest import AblyRest
 from ably.types.options import Options
 from ably.realtime.realtime_channel import RealtimeChannel
 
@@ -9,7 +10,7 @@ from ably.realtime.realtime_channel import RealtimeChannel
 log = logging.getLogger(__name__)
 
 
-class AblyRealtime:
+class AblyRealtime(AblyRest):
     """
     Ably Realtime Client
 
@@ -63,6 +64,8 @@ class AblyRealtime:
         ValueError
             If no authentication key is not provided
         """
+        super().__init__(key, **kwargs)
+
         if loop is None:
             try:
                 loop = asyncio.get_running_loop()
@@ -102,6 +105,7 @@ class AblyRealtime:
         """
         log.info('Realtime.close() called')
         await self.connection.close()
+        await super().close()
 
     @property
     def auth(self):

--- a/ably/realtime/realtime_channel.py
+++ b/ably/realtime/realtime_channel.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 from ably.realtime.connection import ConnectionState, ProtocolMessageAction
+from ably.rest.channel import Channel
 from ably.types.message import Message
 from ably.util.eventemitter import EventEmitter
 from ably.util.exceptions import AblyException
@@ -20,7 +21,7 @@ class ChannelState(str, Enum):
     DETACHED = 'detached'
 
 
-class RealtimeChannel(EventEmitter):
+class RealtimeChannel(EventEmitter, Channel):
     """
     Ably Realtime Channel
 
@@ -44,6 +45,7 @@ class RealtimeChannel(EventEmitter):
     """
 
     def __init__(self, realtime, name):
+        EventEmitter.__init__(self)
         self.__name = name
         self.__attach_future = None
         self.__detach_future = None
@@ -51,7 +53,7 @@ class RealtimeChannel(EventEmitter):
         self.__state = ChannelState.INITIALIZED
         self.__message_emitter = EventEmitter()
         self.__timeout_in_secs = self.__realtime.options.realtime_request_timeout / 1000
-        super().__init__()
+        Channel.__init__(self, realtime, name, {})
 
     async def attach(self):
         """Attach to channel

--- a/test/ably/realtimechannel_test.py
+++ b/test/ably/realtimechannel_test.py
@@ -63,9 +63,7 @@ class TestRealtimeChannel(BaseAsyncTestCase):
         await channel.subscribe('event', listener)
 
         # publish a message using rest client
-        rest = await RestSetup.get_ably_rest()
-        rest_channel = rest.channels.get('my_channel')
-        await rest_channel.publish('event', 'data')
+        await channel.publish('event', 'data')
         message = await first_message_future
 
         assert isinstance(message, Message)
@@ -73,11 +71,10 @@ class TestRealtimeChannel(BaseAsyncTestCase):
         assert message.data == 'data'
 
         # test that the listener is called again for further publishes
-        await rest_channel.publish('event', 'data')
+        await channel.publish('event', 'data')
         await second_message_future
 
         await ably.close()
-        await rest.close()
 
     async def test_subscribe_coroutine(self):
         ably = await RestSetup.get_ably_realtime()

--- a/test/ably/restsetup.py
+++ b/test/ably/restsetup.py
@@ -87,7 +87,8 @@ class RestSetup:
         test_vars = await RestSetup.get_test_vars()
         options = {
             'key': test_vars["keys"][0]["key_str"],
-            'realtime_host': realtime_host,
+            'realtime_host': test_vars["realtime_host"],
+            'rest_host': test_vars["host"],
             'port': test_vars["port"],
             'tls_port': test_vars["tls_port"],
             'tls': test_vars["tls"],


### PR DESCRIPTION
Makes `Realtime` extend `Rest` (necessary for some of the fallback stuff in milestone 2c)