### PR TITLE
Refactor: create `WebSocketTransport` and fix `disconnected_retry_timeout`

### DIFF
--- a/ably/realtime/connection.py
+++ b/ably/realtime/connection.py
@@ -1,12 +1,13 @@
 import functools
 import logging
 import asyncio
+from ably.realtime.connectionmanager import ProtocolMessageAction
 import websockets
 import json
 from ably.http.httputils import HttpUtils
 from ably.util.exceptions import AblyAuthException, AblyException
 from ably.util.eventemitter import EventEmitter
-from enum import Enum, IntEnum
+from enum import Enum
 from datetime import datetime
 from ably.util import helper
 from dataclasses import dataclass
@@ -30,19 +31,6 @@ class ConnectionStateChange:
     previous: ConnectionState
     current: ConnectionState
     reason: Optional[AblyException] = None
-
-
-class ProtocolMessageAction(IntEnum):
-    HEARTBEAT = 0
-    CONNECTED = 4
-    ERROR = 9
-    CLOSE = 7
-    CLOSED = 8
-    ATTACH = 10
-    ATTACHED = 11
-    DETACH = 12
-    DETACHED = 13
-    MESSAGE = 15
 
 
 class Connection(EventEmitter):

--- a/ably/realtime/connection.py
+++ b/ably/realtime/connection.py
@@ -209,8 +209,8 @@ class ConnectionManager(EventEmitter):
     async def send_close_message(self):
         await self.send_protocol_message({"action": ProtocolMessageAction.CLOSE})
 
-    async def send_protocol_message(self, protocolMessage):
-        raw_msg = json.dumps(protocolMessage)
+    async def send_protocol_message(self, protocol_message):
+        raw_msg = json.dumps(protocol_message)
         log.info('send_protocol_message(): sending {raw_msg}')
         await self.__websocket.send(raw_msg)
 

--- a/ably/realtime/connection.py
+++ b/ably/realtime/connection.py
@@ -1,10 +1,7 @@
 import functools
 import logging
 import asyncio
-from ably.realtime.connectionmanager import ProtocolMessageAction
-import websockets
-import json
-from ably.http.httputils import HttpUtils
+from ably.realtime.websockettransport import WebSocketTransport, ProtocolMessageAction
 from ably.util.exceptions import AblyAuthException, AblyException
 from ably.util.eventemitter import EventEmitter
 from enum import Enum
@@ -130,10 +127,9 @@ class ConnectionManager(EventEmitter):
         self.__state = initial_state
         self.__connected_future = asyncio.Future() if initial_state == ConnectionState.CONNECTING else None
         self.__closed_future = None
-        self.__websocket = None
-        self.setup_ws_task = None
         self.__ping_future = None
         self.__timeout_in_secs = self.options.realtime_request_timeout / 1000
+        self.transport: WebSocketTransport | None = None
         super().__init__()
 
     def enact_state_change(self, state, reason=None):
@@ -142,90 +138,96 @@ class ConnectionManager(EventEmitter):
         self._emit('connectionstate', ConnectionStateChange(current_state, state, reason))
 
     async def connect(self):
+        if not self.__connected_future:
+            self.__connected_future = asyncio.Future()
+            self.try_connect()
+        await self.__connected_future
+
+    def try_connect(self):
+        task = asyncio.create_task(self._connect())
+        task.add_done_callback(self.on_connection_attempt_done)
+
+    async def _connect(self):
         if self.__state == ConnectionState.CONNECTED:
             return
 
         if self.__state == ConnectionState.CONNECTING:
-            if self.__connected_future is None:
-                log.fatal('Connection state is CONNECTING but connected_future does not exist')
-                return
             try:
-                print("toh")
+                if not self.__connected_future:
+                    self.__connected_future = asyncio.Future()
                 await self.__connected_future
             except asyncio.CancelledError:
                 exception = AblyException(
                     "Connection cancelled due to request timeout. Attempting reconnection...", 504, 50003)
-                self.enact_state_change(ConnectionState.DISCONNECTED, exception)
                 log.info('Connection cancelled due to request timeout. Attempting reconnection...')
-                print("cancelled error")
                 raise exception
-            self.enact_state_change(ConnectionState.CONNECTED)
         else:
             self.enact_state_change(ConnectionState.CONNECTING)
-            self.__connected_future = asyncio.Future()
             await self.connect_impl()
 
+    def on_connection_attempt_done(self, task):
+        try:
+            exception = task.exception()
+        except asyncio.CancelledError:
+            exception = AblyException(
+                "Connection cancelled due to request timeout. Attempting reconnection...", 504, 50003)
+        if exception is None:
+            return
+        if self.__state in (ConnectionState.CLOSED, ConnectionState.FAILED):
+            return
+        if self.__state != ConnectionState.DISCONNECTED:
+            if self.__connected_future:
+                self.__connected_future.set_exception(exception)
+                self.__connected_future = None
+            self.enact_state_change(ConnectionState.DISCONNECTED, exception)
+
     async def close(self):
+        if self.__state in (ConnectionState.CLOSED, ConnectionState.INITIALIZED, ConnectionState.FAILED):
+            self.enact_state_change(ConnectionState.CLOSED)
+            return
+        if self.__state is ConnectionState.DISCONNECTED:
+            if self.transport:
+                await self.transport.dispose()
+                self.transport = None
+                self.enact_state_change(ConnectionState.CLOSED)
+                return
         if self.__state != ConnectionState.CONNECTED:
             log.warning('Connection.closed called while connection state not connected')
+        if self.__state == ConnectionState.CONNECTING:
+            await self.__connected_future
         self.enact_state_change(ConnectionState.CLOSING)
         self.__closed_future = asyncio.Future()
-        if self.__websocket and self.__state != ConnectionState.FAILED:
-            await self.send_close_message()
+        if self.transport and self.transport.is_connected:
+            await self.transport.close()
             try:
                 await asyncio.wait_for(self.__closed_future, self.__timeout_in_secs)
             except asyncio.TimeoutError:
                 raise AblyException("Timeout waiting for connection close response", 504, 50003)
         else:
-            log.warning('Connection.closed called while connection already closed or not established')
+            log.warning('ConnectionManager: called close with no connected transport')
         self.enact_state_change(ConnectionState.CLOSED)
-        if self.setup_ws_task:
-            await self.setup_ws_task
-
-    def on_setup_ws_done(self, task):
-        exception = task.exception()
-        if exception is not None:
-            if self.__connected_future and not self.__connected_future.cancelled():
-                self.__connected_future.set_exception(exception)
-                self.enact_state_change(ConnectionState.DISCONNECTED, exception)
+        if self.transport and self.transport.ws_connect_task is not None:
+            await self.transport.ws_connect_task
 
     async def connect_impl(self):
-        self.setup_ws_task = self.__ably.options.loop.create_task(self.setup_ws())
-        self.setup_ws_task.add_done_callback(self.on_setup_ws_done)
+        self.transport = WebSocketTransport(self)
+        await self.transport.connect()
         try:
-            await asyncio.wait_for(self.__connected_future, self.__timeout_in_secs)
+            await asyncio.wait_for(asyncio.shield(self.__connected_future), self.__timeout_in_secs)
         except asyncio.TimeoutError:
             exception = AblyException("Timeout waiting for realtime connection", 504, 50003)
-            self.enact_state_change(ConnectionState.CONNECTING, exception)
-            await asyncio.sleep(self.options.disconnected_retry_timeout / 1000)
-            log.info('Attempting reconnection')
-            self.__connected_future = asyncio.Future()
-            print("timeout error")
-            # task.add_done_callback(self.on_setup_ws_done)
-            # task = self.__ably.options.loop.create_task(self.connect())
-            self.__ably.options.loop.create_task(self.connect())
-        self.enact_state_change(ConnectionState.CONNECTED)
-
-    async def send_close_message(self):
-        await self.send_protocol_message({"action": ProtocolMessageAction.CLOSE})
+            self.enact_state_change(ConnectionState.DISCONNECTED, exception)
+            if self.transport:
+                await self.transport.dispose()
+                self.tranpsort = None
+            self.__connected_future.set_exception(exception)
+            raise exception
 
     async def send_protocol_message(self, protocol_message):
-        raw_msg = json.dumps(protocol_message)
-        log.info('send_protocol_message(): sending {raw_msg}')
-        await self.__websocket.send(raw_msg)
-
-    async def setup_ws(self):
-        headers = HttpUtils.default_headers()
-        ws_url = f'wss://{self.options.get_realtime_host()}?key={self.__ably.key}'
-        log.info(f'setup_ws(): attempting to connect to {ws_url}')
-        async with websockets.connect(ws_url, extra_headers=headers) as websocket:
-            log.info(f'setup_ws(): connection established to {ws_url}')
-            self.__websocket = websocket
-            task = self.__ably.options.loop.create_task(self.ws_read_loop())
-            try:
-                await task
-            except AblyAuthException:
-                return
+        if self.transport is not None:
+            await self.transport.send(protocol_message)
+        else:
+            raise Exception()
 
     async def ping(self):
         if self.__ping_future:
@@ -252,48 +254,47 @@ class ConnectionManager(EventEmitter):
         response_time_ms = (ping_end_time - ping_start_time) * 1000
         return round(response_time_ms, 2)
 
-    async def ws_read_loop(self):
-        while True:
-            raw = await self.__websocket.recv()
-            msg = json.loads(raw)
-            log.info(f'ws_read_loop(): receieved protocol message: {msg}')
-            action = msg['action']
-            if action == ProtocolMessageAction.CONNECTED:  # CONNECTED
+    async def on_protocol_message(self, msg):
+        action = msg['action']
+        if action == ProtocolMessageAction.CONNECTED:  # CONNECTED
+            if self.transport:
+                self.transport.is_connected = True
+            if self.__connected_future:
+                if not self.__connected_future.cancelled():
+                    self.__connected_future.set_result(None)
+                self.__connected_future = None
+            else:
+                log.warn('CONNECTED message received but connected_future not set')
+            self.enact_state_change(ConnectionState.CONNECTED)
+        if action == ProtocolMessageAction.ERROR:  # ERROR
+            error = msg["error"]
+            if error['nonfatal'] is False:
+                exception = AblyAuthException(error["message"], error["statusCode"], error["code"])
+                self.enact_state_change(ConnectionState.FAILED, exception)
                 if self.__connected_future:
-                    if not self.__connected_future.cancelled():
-                        self.__connected_future.set_result(None)
+                    self.__connected_future.set_exception(exception)
                     self.__connected_future = None
-                else:
-                    log.warn('CONNECTED message received but connected_future not set')
-            if action == ProtocolMessageAction.ERROR:  # ERROR
-                error = msg["error"]
-                if error['nonfatal'] is False:
-                    exception = AblyAuthException(error["message"], error["statusCode"], error["code"])
-                    self.enact_state_change(ConnectionState.FAILED, exception)
-                    if self.__connected_future:
-                        self.__connected_future.set_exception(exception)
-                        self.__connected_future = None
-                    self.__websocket = None
-                    raise exception
-            if action == ProtocolMessageAction.CLOSED:
-                await self.__websocket.close()
-                self.__websocket = None
-                self.__closed_future.set_result(None)
-                break
-            if action == ProtocolMessageAction.HEARTBEAT:
-                if self.__ping_future:
-                    # Resolve on heartbeat from ping request.
-                    # TODO: Handle Normal heartbeat if required
-                    if self.__ping_id == msg.get("id"):
-                        if not self.__ping_future.cancelled():
-                            self.__ping_future.set_result(None)
-                        self.__ping_future = None
-            if action in (
-                ProtocolMessageAction.ATTACHED,
-                ProtocolMessageAction.DETACHED,
-                ProtocolMessageAction.MESSAGE
-            ):
-                self.__ably.channels._on_channel_message(msg)
+                if self.transport:
+                    await self.transport.dispose()
+                raise exception
+        if action == ProtocolMessageAction.CLOSED:
+            if self.transport:
+                await self.transport.dispose()
+            self.__closed_future.set_result(None)
+        if action == ProtocolMessageAction.HEARTBEAT:
+            if self.__ping_future:
+                # Resolve on heartbeat from ping request.
+                # TODO: Handle Normal heartbeat if required
+                if self.__ping_id == msg.get("id"):
+                    if not self.__ping_future.cancelled():
+                        self.__ping_future.set_result(None)
+                    self.__ping_future = None
+        if action in (
+            ProtocolMessageAction.ATTACHED,
+            ProtocolMessageAction.DETACHED,
+            ProtocolMessageAction.MESSAGE
+        ):
+            self.__ably.channels._on_channel_message(msg)
 
     @property
     def ably(self):

--- a/ably/realtime/connection.py
+++ b/ably/realtime/connection.py
@@ -180,6 +180,11 @@ class ConnectionManager(EventEmitter):
                 self.__connected_future.set_exception(exception)
                 self.__connected_future = None
             self.enact_state_change(ConnectionState.DISCONNECTED, exception)
+        asyncio.create_task(self.retry_connection_attempt())
+
+    async def retry_connection_attempt(self):
+        await asyncio.sleep(self.ably.options.disconnected_retry_timeout / 1000)
+        self.try_connect()
 
     async def close(self):
         if self.__state in (ConnectionState.CLOSED, ConnectionState.INITIALIZED, ConnectionState.FAILED):

--- a/ably/realtime/realtime.py
+++ b/ably/realtime/realtime.py
@@ -83,7 +83,6 @@ class AblyRealtime:
         self.key = key
         self.__connection = Connection(self)
         self.__channels = Channels(self)
-        print(options.auto_connect, "+++")
         if options.auto_connect:
             asyncio.ensure_future(self.connection.connection_manager.connect_impl())
 

--- a/ably/realtime/websockettransport.py
+++ b/ably/realtime/websockettransport.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+import asyncio
+from enum import IntEnum
+import json
+import logging
+from ably.http.httputils import HttpUtils
+from websockets.client import WebSocketClientProtocol, connect as ws_connect
+from websockets.exceptions import ConnectionClosedOK
+
+if TYPE_CHECKING:
+    from ably.realtime.connection import ConnectionManager
+
+log = logging.getLogger(__name__)
+
+
+class ProtocolMessageAction(IntEnum):
+    HEARTBEAT = 0
+    CONNECTED = 4
+    ERROR = 9
+    CLOSE = 7
+    CLOSED = 8
+    ATTACH = 10
+    ATTACHED = 11
+    DETACH = 12
+    DETACHED = 13
+    MESSAGE = 15
+
+
+class WebSocketTransport:
+    def __init__(self, connection_manager: ConnectionManager):
+        self.websocket: WebSocketClientProtocol | None = None
+        self.read_loop: asyncio.Task | None = None
+        self.connect_task: asyncio.Task | None = None
+        self.ws_connect_task: asyncio.Task | None = None
+        self.connection_manager = connection_manager
+        self.is_connected = False
+
+    async def connect(self):
+        headers = HttpUtils.default_headers()
+        host = self.connection_manager.options.get_realtime_host()
+        key = self.connection_manager.ably.key
+        ws_url = f'wss://{host}?key={key}'
+        log.info(f'connect(): attempting to connect to {ws_url}')
+        self.ws_connect_task = asyncio.create_task(self.ws_connect(ws_url, headers))
+        self.ws_connect_task.add_done_callback(self.on_ws_connect_done)
+
+    def on_ws_connect_done(self, task: asyncio.Task):
+        try:
+            exception = task.exception()
+        except asyncio.CancelledError as e:
+            exception = e
+        if isinstance(exception, ConnectionClosedOK):
+            return
+
+    async def ws_connect(self, ws_url, headers):
+        async with ws_connect(ws_url, extra_headers=headers) as websocket:
+            log.info(f'ws_connect(): connection established to {ws_url}')
+            self.websocket = websocket
+            self.read_loop = self.connection_manager.options.loop.create_task(self.ws_read_loop())
+            self.read_loop.add_done_callback(self.on_read_loop_done)
+            await self.read_loop
+
+    async def ws_read_loop(self):
+        while True:
+            if self.websocket is not None:
+                try:
+                    raw = await self.websocket.recv()
+                except ConnectionClosedOK:
+                    break
+                msg = json.loads(raw)
+                log.info(f'ws_read_loop(): receieved protocol message: {msg}')
+                if msg['action'] == ProtocolMessageAction.CLOSED:
+                    if self.ws_connect_task:
+                        self.ws_connect_task.cancel()
+                await self.connection_manager.on_protocol_message(msg)
+            else:
+                raise Exception()
+
+    def on_read_loop_done(self, task: asyncio.Task):
+        try:
+            exception = task.exception()
+        except asyncio.CancelledError as e:
+            exception = e
+        if isinstance(exception, ConnectionClosedOK):
+            return
+
+    async def dispose(self):
+        if self.read_loop:
+            self.read_loop.cancel()
+        if self.ws_connect_task:
+            self.ws_connect_task.cancel()
+        if self.websocket:
+            try:
+                await self.websocket.close()
+            except asyncio.CancelledError:
+                return
+
+    async def close(self):
+        await self.send({'action': ProtocolMessageAction.CLOSE})
+
+    async def send(self, message: dict):
+        if self.websocket is None:
+            raise Exception()
+        raw_msg = json.dumps(message)
+        log.info(f'WebSocketTransport.send(): sending {raw_msg}')
+        await self.websocket.send(raw_msg)

--- a/ably/realtime/websockettransport.py
+++ b/ably/realtime/websockettransport.py
@@ -75,7 +75,7 @@ class WebSocketTransport:
                         self.ws_connect_task.cancel()
                 await self.connection_manager.on_protocol_message(msg)
             else:
-                raise Exception()
+                raise Exception('ws_read_loop running with no websocket')
 
     def on_read_loop_done(self, task: asyncio.Task):
         try:

--- a/test/ably/realtimeconnection_test.py
+++ b/test/ably/realtimeconnection_test.py
@@ -156,13 +156,11 @@ class TestRealtimeAuth(BaseAsyncTestCase):
     async def test_realtime_request_timeout_close(self):
         ably = await RestSetup.get_ably_realtime(realtime_request_timeout=2000)
         await ably.connect()
-        original_send_protocol_message = ably.connection.connection_manager.send_protocol_message
 
-        async def new_send_protocol_message(msg):
-            if msg.get('action') == ProtocolMessageAction.CLOSE:
-                return
-            await original_send_protocol_message(msg)
-        ably.connection.connection_manager.send_protocol_message = new_send_protocol_message
+        async def new_close_transport():
+            pass
+
+        ably.connection.connection_manager.transport.close = new_close_transport
 
         with pytest.raises(AblyException) as exception:
             await ably.close()

--- a/test/ably/realtimeconnection_test.py
+++ b/test/ably/realtimeconnection_test.py
@@ -134,7 +134,7 @@ class TestRealtimeAuth(BaseAsyncTestCase):
         assert exception.value.status_code == 504
         assert ably.connection.state == ConnectionState.DISCONNECTED
         assert ably.connection.error_reason == exception.value
-        ably.close()
+        await ably.close()
 
     async def test_realtime_request_timeout_ping(self):
         ably = await RestSetup.get_ably_realtime(realtime_request_timeout=2000)
@@ -188,4 +188,4 @@ class TestRealtimeAuth(BaseAsyncTestCase):
         assert len(state_changes) == 4
         assert state_changes[0].previous == ConnectionState.CONNECTING
         assert state_changes[0].current == ConnectionState.DISCONNECTED
-        ably.close()
+        await ably.close()


### PR DESCRIPTION
Resolves #373 

- Adds `WebSocketTransport` to handle lifecycle of async WebSocket related tasks
- Refactors `DISCONNECTED` retry logic to ensure a fresh transport is created for each attempt