### PR TITLE
Refactor(Connection): make `connect` synchronous, refactor internal connection state logic

### DIFF
--- a/ably/realtime/connection.py
+++ b/ably/realtime/connection.py
@@ -400,6 +400,14 @@ class ConnectionManager(EventEmitter):
 
         self.enact_state_change(state)
 
+    def notify_state(self, state: ConnectionState, reason=None):
+        log.info(f'ConnectionManager.notify_state(): new state: {state}')
+
+        if state == self.__state:
+            return
+
+        self.enact_state_change(state, reason)
+
     @property
     def ably(self):
         return self.__ably

--- a/ably/realtime/connection.py
+++ b/ably/realtime/connection.py
@@ -386,6 +386,20 @@ class ConnectionManager(EventEmitter):
         self.transport = None
         self.enact_state_change(ConnectionState.DISCONNECTED, reason)
 
+    def request_state(self, state: ConnectionState):
+        log.info(f'ConnectionManager.request_state(): state = {state}')
+
+        if state == self.state:
+            return
+
+        if state == ConnectionState.CONNECTING and self.__state == ConnectionState.CONNECTED:
+            return
+
+        if state == ConnectionState.CLOSING and self.__state == ConnectionState.CLOSED:
+            return
+
+        self.enact_state_change(state)
+
     @property
     def ably(self):
         return self.__ably

--- a/ably/realtime/connection.py
+++ b/ably/realtime/connection.py
@@ -293,7 +293,7 @@ class ConnectionManager(EventEmitter):
     async def connect_impl(self):
         self.transport = WebSocketTransport(self)  # RTN1
         self._emit('transport.pending', self.transport)
-        await self.transport.connect()
+        self.transport.connect()
         try:
             await asyncio.wait_for(asyncio.shield(self.__connected_future), self.__timeout_in_secs)
         except asyncio.TimeoutError:

--- a/ably/realtime/connection.py
+++ b/ably/realtime/connection.py
@@ -80,13 +80,13 @@ class Connection(EventEmitter):  # RTN4
         super().__init__()
 
     # RTN11
-    async def connect(self):
+    def connect(self):
         """Establishes a realtime connection.
 
         Causes the connection to open, entering the connecting state
         """
         self.__error_reason = None
-        await self.__connection_manager.connect()
+        self.connection_manager.request_state(ConnectionState.CONNECTING)
 
     async def close(self):
         """Causes the connection to close, entering the closing state.
@@ -94,7 +94,8 @@ class Connection(EventEmitter):  # RTN4
         Once closed, the library will not attempt to re-establish the
         connection without an explicit call to connect()
         """
-        await self.__connection_manager.close()
+        self.connection_manager.request_state(ConnectionState.CLOSING)
+        await self.once_async(ConnectionState.CLOSED)
 
     # RTN13
     async def ping(self):
@@ -155,64 +156,23 @@ class ConnectionManager(EventEmitter):
         self.options = realtime.options
         self.__ably = realtime
         self.__state = initial_state
-        self.__connected_future = asyncio.Future() if initial_state == ConnectionState.CONNECTING else None
-        self.__closed_future = None
         self.__ping_future = None
         self.__timeout_in_secs = self.options.realtime_request_timeout / 1000
-        self.retry_connection_attempt_task = None
-        self.connection_attempt_task = None
         self.transport: WebSocketTransport | None = None
-        self.__ttl_task = None
         self.__connection_details = None
         self.__fail_state = ConnectionState.DISCONNECTED
         self.transition_timer: Timer | None = None
         self.suspend_timer: Timer | None = None
+        self.retry_timer: Timer | None = None
+        self.connect_base_task: asyncio.Task | None = None
+        self.disconnect_transport_task: asyncio.Task | None = None
         super().__init__()
 
     def enact_state_change(self, state, reason=None):
         current_state = self.__state
+        log.info(f'ConnectionManager.enact_state_change(): {current_state} -> {state}')
         self.__state = state
-        if self.__state == ConnectionState.DISCONNECTED:
-            if not self.__ttl_task or self.__ttl_task.done():
-                self.__ttl_task = asyncio.create_task(self.__start_suspended_timer())
         self._emit('connectionstate', ConnectionStateChange(current_state, state, state, reason))
-
-    async def __start_suspended_timer(self):
-        if self.__connection_details:
-            self.ably.options.connection_state_ttl = self.__connection_details.connection_state_ttl
-        await asyncio.sleep(self.ably.options.connection_state_ttl / 1000)
-        exception = AblyException("Exceeded connectionStateTtl while in DISCONNECTED state", 504, 50003)  # RTN14e
-        self.enact_state_change(ConnectionState.SUSPENDED, exception)
-        self.__connection_details = None
-        self.__fail_state = ConnectionState.SUSPENDED
-
-    async def connect(self):
-        if not self.__connected_future:
-            self.__connected_future = asyncio.Future()
-            self.try_connect()
-        await self.__connected_future
-
-    def try_connect(self):
-        self.connection_attempt_task = asyncio.create_task(self._connect())
-        self.connection_attempt_task.add_done_callback(self.on_connection_attempt_done)
-
-    async def _connect(self):
-        if self.__state == ConnectionState.CONNECTED:
-            return
-
-        if self.__state == ConnectionState.CONNECTING:
-            try:
-                if not self.__connected_future:
-                    self.__connected_future = asyncio.Future()
-                await self.__connected_future
-            except asyncio.CancelledError:
-                exception = AblyException(
-                    "Connection cancelled due to request timeout. Attempting reconnection...", 504, 50003)
-                log.info('Connection cancelled due to request timeout. Attempting reconnection...')
-                raise exception
-        else:
-            self.enact_state_change(ConnectionState.CONNECTING)
-            await self.connect_impl()
 
     def check_connection(self):
         try:
@@ -222,91 +182,20 @@ class ConnectionManager(EventEmitter):
         except httpx.HTTPError:
             return False
 
-    def on_connection_attempt_done(self, task):
-        if self.connection_attempt_task:
-            if not self.connection_attempt_task.done():
-                self.connection_attempt_task.cancel()
-            self.connection_attempt_task = None
-        if self.retry_connection_attempt_task:
-            if not self.retry_connection_attempt_task.done():
-                self.retry_connection_attempt_task.cancel()
-            self.retry_connection_attempt_task = None
-        try:
-            exception = task.exception()
-        except asyncio.CancelledError:
-            exception = AblyException(
-                "Connection cancelled due to request timeout. Attempting reconnection...", 504, 50003)
-        if exception is None:
-            return
-        if self.__state in (ConnectionState.CLOSED, ConnectionState.FAILED):
-            return
-        if self.__state != ConnectionState.DISCONNECTED:
-            if self.__connected_future:
-                self.__connected_future.set_exception(exception)
-                self.__connected_future = None
-            self.enact_state_change(ConnectionState.DISCONNECTED, exception)  # RTN14d
-        self.retry_connection_attempt_task = asyncio.create_task(self.retry_connection_attempt())
+    async def close_impl(self):
+        log.debug('ConnectionManager.close_impl()')
 
-    async def retry_connection_attempt(self):
-        if self.__fail_state == ConnectionState.SUSPENDED:
-            retry_timeout = self.ably.options.suspended_retry_timeout / 1000
-        else:
-            retry_timeout = self.ably.options.disconnected_retry_timeout / 1000
-        await asyncio.sleep(retry_timeout)
-        if self.check_connection():
-            self.try_connect()
-        else:
-            exception = AblyException("Unable to connect (network unreachable)", 80003, 404)
-            self.enact_state_change(self.__fail_state, exception)
+        self.cancel_suspend_timer()
+        self.start_transition_timer(ConnectionState.CLOSING, fail_state=ConnectionState.CLOSED)
+        if self.transport:
+            await self.transport.dispose()
+        if self.connect_base_task:
+            self.connect_base_task.cancel()
+        if self.disconnect_transport_task:
+            await self.disconnect_transport_task
+        self.cancel_retry_timer()
 
-    async def close(self):
-        if self.__state in (ConnectionState.CLOSED, ConnectionState.INITIALIZED, ConnectionState.FAILED):
-            self.enact_state_change(ConnectionState.CLOSED)
-            return
-        if self.__state is ConnectionState.DISCONNECTED:
-            if self.transport:
-                await self.transport.dispose()
-                self.transport = None
-                self.enact_state_change(ConnectionState.CLOSED)
-                return
-        if self.__state != ConnectionState.CONNECTED:
-            log.warning('Connection.closed called while connection state not connected')
-        if self.__state == ConnectionState.CONNECTING:
-            await self.__connected_future
-        self.enact_state_change(ConnectionState.CLOSING)
-        self.__closed_future = asyncio.Future()
-        if self.transport and self.transport.is_connected:
-            await self.transport.close()
-            try:
-                await asyncio.wait_for(self.__closed_future, self.__timeout_in_secs)
-            except asyncio.TimeoutError:
-                raise AblyException("Timeout waiting for connection close response", 504, 50003)
-        else:
-            log.warning('ConnectionManager: called close with no connected transport')
-        self.enact_state_change(ConnectionState.CLOSED)
-        if self.__ttl_task and not self.__ttl_task.done():
-            self.__ttl_task.cancel()
-        if self.transport and self.transport.ws_connect_task is not None:
-            try:
-                await self.transport.ws_connect_task
-            except AblyException as e:
-                log.warning(f'Connection error encountered while closing: {e}')
-
-    async def connect_impl(self):
-        self.transport = WebSocketTransport(self)  # RTN1
-        self._emit('transport.pending', self.transport)
-        self.transport.connect()
-        try:
-            await asyncio.wait_for(asyncio.shield(self.__connected_future), self.__timeout_in_secs)
-        except asyncio.TimeoutError:
-            exception = AblyException("Timeout waiting for realtime connection", 504, 50003)  # RTN14c
-            if self.transport:
-                await self.transport.dispose()
-                self.tranpsort = None
-            self.__connected_future.set_exception(exception)
-            connected_future = self.__connected_future
-            self.__connected_future = None
-            self.on_connection_attempt_done(connected_future)
+        self.notify_state(ConnectionState.CLOSED)
 
     async def send_protocol_message(self, protocol_message):
         if self.transport is not None:
@@ -340,29 +229,20 @@ class ConnectionManager(EventEmitter):
         return round(response_time_ms, 2)
 
     def on_connected(self, connection_details: ConnectionDetails):
-        if self.transport:
-            self.transport.is_connected = True
-        if self.__connected_future:
-            if not self.__connected_future.cancelled():
-                self.__connected_future.set_result(None)
-            self.__connected_future = None
         self.__fail_state = ConnectionState.DISCONNECTED
-        if self.__ttl_task:
-            self.__ttl_task.cancel()
-        self.__connection_details = connection_details  # RTN21
-        if self.__state == ConnectionState.CONNECTED:  # RTN24
+
+        self.__connection_details = connection_details
+
+        if self.__state == ConnectionState.CONNECTED:
             state_change = ConnectionStateChange(ConnectionState.CONNECTED, ConnectionState.CONNECTED,
                                                  ConnectionEvent.UPDATE)
             self._emit(ConnectionEvent.UPDATE, state_change)
         else:
-            self.enact_state_change(ConnectionState.CONNECTED)
+            self.notify_state(ConnectionState.CONNECTED)
 
     async def on_error(self, msg: dict, exception: AblyException):
         if msg.get('channel') is None:  # RTN15i
             self.enact_state_change(ConnectionState.FAILED, exception)
-            if self.__connected_future:
-                self.__connected_future.set_exception(exception)
-                self.__connected_future = None
             if self.transport:
                 await self.transport.dispose()
             raise exception
@@ -370,8 +250,8 @@ class ConnectionManager(EventEmitter):
     async def on_closed(self):
         if self.transport:
             await self.transport.dispose()
-        if self.__closed_future and not self.__closed_future.done():
-            self.__closed_future.set_result(None)
+        if self.connect_base_task:
+            self.connect_base_task.cancel()
 
     def on_channel_message(self, msg: dict):
         self.__ably.channels._on_channel_message(msg)
@@ -388,10 +268,10 @@ class ConnectionManager(EventEmitter):
         self.transport = None
         self.enact_state_change(ConnectionState.DISCONNECTED, reason)
 
-    def request_state(self, state: ConnectionState):
+    def request_state(self, state: ConnectionState, force=False):
         log.info(f'ConnectionManager.request_state(): state = {state}')
 
-        if state == self.state:
+        if not force and state == self.state:
             return
 
         if state == ConnectionState.CONNECTING and self.__state == ConnectionState.CONNECTED:
@@ -400,10 +280,14 @@ class ConnectionManager(EventEmitter):
         if state == ConnectionState.CLOSING and self.__state == ConnectionState.CLOSED:
             return
 
-        self.enact_state_change(state)
+        if not force:
+            self.enact_state_change(state)
 
         if state == ConnectionState.CONNECTING:
             self.start_connect()
+
+        if state == ConnectionState.CLOSING:
+            asyncio.create_task(self.close_impl())
 
     def start_connect(self):
         self.start_suspend_timer()
@@ -433,7 +317,10 @@ class ConnectionManager(EventEmitter):
         self.transport.once('connected', on_transport_connected)
         self.transport.once('failed', on_transport_failed)
 
-        await future
+        try:
+            await future
+        except Exception as exception:
+            self.notify_state(self.__fail_state, reason=exception)
 
     def notify_state(self, state: ConnectionState, reason=None):
         log.info(f'ConnectionManager.notify_state(): new state: {state}')
@@ -449,23 +336,29 @@ class ConnectionManager(EventEmitter):
         elif state == ConnectionState.SUSPENDED:
             self.start_retry_timer(self.options.suspended_retry_timeout)
 
+        if state == ConnectionState.DISCONNECTED or state == ConnectionState.SUSPENDED:
+            self.disconnect_transport()
+
         self.enact_state_change(state, reason)
 
-    def start_transition_timer(self, state: ConnectionState):
+    def start_transition_timer(self, state: ConnectionState, fail_state=None):
         log.debug(f'ConnectionManager.start_transition_timer(): transition state = {state}')
 
         if self.transition_timer:
             log.debug('ConnectionManager.start_transition_timer(): clearing already-running timer')
             self.transition_timer.cancel()
 
+        if fail_state is None:
+            fail_state = self.__fail_state if state != ConnectionState.CLOSING else ConnectionState.CLOSED
+
         timeout = self.options.realtime_request_timeout
 
         def on_transition_timer_expire():
             if self.transition_timer:
                 self.transition_timer = None
-                log.info(f'ConnectionManager {state} timer expired, notifying new state: {self.__fail_state}')
+                log.info(f'ConnectionManager {state} timer expired, notifying new state: {fail_state}')
                 self.notify_state(
-                    self.__fail_state,
+                    fail_state,
                     AblyException("Connection cancelled due to request timeout", 504, 50003)
                 )
 
@@ -524,6 +417,11 @@ class ConnectionManager(EventEmitter):
         if self.retry_timer:
             self.retry_timer.cancel()
             self.retry_timer = None
+
+    def disconnect_transport(self):
+        log.info('ConnectionManager.disconnect_transport()')
+        if self.transport:
+            self.disconnect_transport_task = asyncio.create_task(self.transport.dispose())
 
     @property
     def ably(self):

--- a/ably/realtime/realtime.py
+++ b/ably/realtime/realtime.py
@@ -1,6 +1,6 @@
 import logging
 import asyncio
-from ably.realtime.connection import Connection
+from ably.realtime.connection import Connection, ConnectionState
 from ably.rest.auth import Auth
 from ably.rest.rest import AblyRest
 from ably.types.options import Options
@@ -105,10 +105,10 @@ class AblyRealtime(AblyRest):
 
         # RTN3
         if options.auto_connect:
-            asyncio.ensure_future(self.connection.connection_manager.connect_impl())
+            self.connection.connection_manager.request_state(ConnectionState.CONNECTING, force=True)
 
     # RTC15
-    async def connect(self):
+    def connect(self):
         """Establishes a realtime connection.
 
         Explicitly calling connect() is unnecessary unless the autoConnect attribute of the ClientOptions object
@@ -117,7 +117,7 @@ class AblyRealtime(AblyRest):
         """
         log.info('Realtime.connect() called')
         # RTC15a
-        await self.connection.connect()
+        self.connection.connect()
 
     # RTC16
     async def close(self):

--- a/ably/realtime/websockettransport.py
+++ b/ably/realtime/websockettransport.py
@@ -46,7 +46,7 @@ class WebSocketTransport:
         self.last_activity = None
         self.max_idle_interval = None
 
-    async def connect(self):
+    def connect(self):
         headers = HttpUtils.default_headers()
         protocol_version = Defaults.protocol_version
         params = {"key": self.connection_manager.ably.key, "v": protocol_version}

--- a/ably/realtime/websockettransport.py
+++ b/ably/realtime/websockettransport.py
@@ -9,6 +9,7 @@ import urllib.parse
 from ably.http.httputils import HttpUtils
 from ably.transport.defaults import Defaults
 from ably.types.connectiondetails import ConnectionDetails
+from ably.util.eventemitter import EventEmitter
 from ably.util.exceptions import AblyException
 from ably.util.helper import Timer, unix_time_ms
 from websockets.client import WebSocketClientProtocol, connect as ws_connect
@@ -33,7 +34,7 @@ class ProtocolMessageAction(IntEnum):
     MESSAGE = 15
 
 
-class WebSocketTransport:
+class WebSocketTransport(EventEmitter):
     def __init__(self, connection_manager: ConnectionManager):
         self.websocket: WebSocketClientProtocol | None = None
         self.read_loop: asyncio.Task | None = None
@@ -45,6 +46,7 @@ class WebSocketTransport:
         self.idle_timer = None
         self.last_activity = None
         self.max_idle_interval = None
+        super().__init__()
 
     def connect(self):
         headers = HttpUtils.default_headers()
@@ -71,12 +73,16 @@ class WebSocketTransport:
         try:
             async with ws_connect(ws_url, extra_headers=headers) as websocket:
                 log.info(f'ws_connect(): connection established to {ws_url}')
+                self._emit('connected')
                 self.websocket = websocket
                 self.read_loop = self.connection_manager.options.loop.create_task(self.ws_read_loop())
                 self.read_loop.add_done_callback(self.on_read_loop_done)
                 await self.read_loop
         except (WebSocketException, socket.gaierror) as e:
-            raise AblyException(f'Error opening websocket connection: {e}', 400, 40000)
+            exception = AblyException(f'Error opening websocket connection: {e}', 400, 40000)
+            log.exception(f'WebSocketTransport.ws_connect(): Error opening websocket connection: {exception}')
+            self._emit('failed', exception)
+            raise exception
 
     async def on_protocol_message(self, msg):
         self.on_activity()

--- a/ably/util/eventemitter.py
+++ b/ably/util/eventemitter.py
@@ -1,3 +1,4 @@
+import asyncio
 from pyee.asyncio import AsyncIOEventEmitter
 
 from ably.util.helper import is_callable_or_coroutine
@@ -99,6 +100,21 @@ class EventEmitter:
             self.__named_event_emitter.remove_listener(args[0], args[1])
         else:
             raise ValueError("EventEmitter.once(): invalid args")
+
+    async def once_async(self, state=None):
+        future = asyncio.Future()
+
+        def on_state_change(*args):
+            future.set_result(*args)
+
+        if state is not None:
+            self.once(state, on_state_change)
+        else:
+            self.once(on_state_change)
+
+        state_change = await future
+
+        return state_change
 
     def _emit(self, *args):
         self.__named_event_emitter.emit(*args)

--- a/test/ably/realtimechannel_test.py
+++ b/test/ably/realtimechannel_test.py
@@ -4,7 +4,7 @@ from ably.realtime.realtime_channel import ChannelState
 from ably.types.message import Message
 from test.ably.restsetup import RestSetup
 from test.ably.utils import BaseAsyncTestCase
-from ably.realtime.connection import ProtocolMessageAction
+from ably.realtime.connection import ConnectionState, ProtocolMessageAction
 from ably.util.exceptions import AblyException
 
 
@@ -28,7 +28,7 @@ class TestRealtimeChannel(BaseAsyncTestCase):
 
     async def test_channel_attach(self):
         ably = await RestSetup.get_ably_realtime()
-        await ably.connect()
+        await ably.connection.once_async(ConnectionState.CONNECTED)
         channel = ably.channels.get('my_channel')
         assert channel.state == ChannelState.INITIALIZED
         await channel.attach()
@@ -37,7 +37,7 @@ class TestRealtimeChannel(BaseAsyncTestCase):
 
     async def test_channel_detach(self):
         ably = await RestSetup.get_ably_realtime()
-        await ably.connect()
+        await ably.connection.once_async(ConnectionState.CONNECTED)
         channel = ably.channels.get('my_channel')
         await channel.attach()
         await channel.detach()
@@ -57,7 +57,7 @@ class TestRealtimeChannel(BaseAsyncTestCase):
             else:
                 second_message_future.set_result(message)
 
-        await ably.connect()
+        await ably.connection.once_async(ConnectionState.CONNECTED)
         channel = ably.channels.get('my_channel')
         await channel.attach()
         await channel.subscribe('event', listener)
@@ -78,7 +78,7 @@ class TestRealtimeChannel(BaseAsyncTestCase):
 
     async def test_subscribe_coroutine(self):
         ably = await RestSetup.get_ably_realtime()
-        await ably.connect()
+        await ably.connection.once_async(ConnectionState.CONNECTED)
         channel = ably.channels.get('my_channel')
         await channel.attach()
 
@@ -106,7 +106,7 @@ class TestRealtimeChannel(BaseAsyncTestCase):
     # RTL7a
     async def test_subscribe_all_events(self):
         ably = await RestSetup.get_ably_realtime()
-        await ably.connect()
+        await ably.connection.once_async(ConnectionState.CONNECTED)
         channel = ably.channels.get('my_channel')
         await channel.attach()
 
@@ -133,7 +133,7 @@ class TestRealtimeChannel(BaseAsyncTestCase):
     # RTL7c
     async def test_subscribe_auto_attach(self):
         ably = await RestSetup.get_ably_realtime()
-        await ably.connect()
+        await ably.connection.once_async(ConnectionState.CONNECTED)
         channel = ably.channels.get('my_channel')
         assert channel.state == ChannelState.INITIALIZED
 
@@ -149,7 +149,7 @@ class TestRealtimeChannel(BaseAsyncTestCase):
     # RTL8b
     async def test_unsubscribe(self):
         ably = await RestSetup.get_ably_realtime()
-        await ably.connect()
+        await ably.connection.once_async(ConnectionState.CONNECTED)
         channel = ably.channels.get('my_channel')
         await channel.attach()
 
@@ -184,7 +184,7 @@ class TestRealtimeChannel(BaseAsyncTestCase):
     # RTL8c
     async def test_unsubscribe_all(self):
         ably = await RestSetup.get_ably_realtime()
-        await ably.connect()
+        await ably.connection.once_async(ConnectionState.CONNECTED)
         channel = ably.channels.get('my_channel')
         await channel.attach()
 
@@ -218,7 +218,7 @@ class TestRealtimeChannel(BaseAsyncTestCase):
 
     async def test_realtime_request_timeout_attach(self):
         ably = await RestSetup.get_ably_realtime(realtime_request_timeout=2000)
-        await ably.connect()
+        await ably.connection.once_async(ConnectionState.CONNECTED)
         original_send_protocol_message = ably.connection.connection_manager.send_protocol_message
 
         async def new_send_protocol_message(msg):
@@ -236,7 +236,7 @@ class TestRealtimeChannel(BaseAsyncTestCase):
 
     async def test_realtime_request_timeout_detach(self):
         ably = await RestSetup.get_ably_realtime(realtime_request_timeout=2000)
-        await ably.connect()
+        await ably.connection.once_async(ConnectionState.CONNECTED)
         original_send_protocol_message = ably.connection.connection_manager.send_protocol_message
 
         async def new_send_protocol_message(msg):

--- a/test/ably/realtimeconnection_test.py
+++ b/test/ably/realtimeconnection_test.py
@@ -15,38 +15,34 @@ class TestRealtimeConnection(BaseAsyncTestCase):
     async def test_connection_state(self):
         ably = await RestSetup.get_ably_realtime(auto_connect=False)
         assert ably.connection.state == ConnectionState.INITIALIZED
-        await ably.connect()
+        ably.connect()
+        await ably.connection.once_async()
+        assert ably.connection.state == ConnectionState.CONNECTING
+        await ably.connection.once_async()
         assert ably.connection.state == ConnectionState.CONNECTED
         await ably.close()
         assert ably.connection.state == ConnectionState.CLOSED
 
-    async def test_connecting_state(self):
+    async def test_connection_state_is_connecting_on_init(self):
         ably = await RestSetup.get_ably_realtime()
-        task = asyncio.create_task(ably.connect())
-        await asyncio.sleep(0)
         assert ably.connection.state == ConnectionState.CONNECTING
-        await task
         await ably.close()
-
-    async def test_closing_state(self):
-        ably = await RestSetup.get_ably_realtime()
-        await ably.connect()
-        task = asyncio.create_task(ably.close())
-        await asyncio.sleep(0)
-        assert ably.connection.state == ConnectionState.CLOSING
-        await task
 
     async def test_auth_invalid_key(self):
         ably = await RestSetup.get_ably_realtime(key=self.valid_key_format)
-        with pytest.raises(AblyException) as exception:
-            await ably.connect()
+        state_change = await ably.connection.once_async()
         assert ably.connection.state == ConnectionState.FAILED
-        assert ably.connection.error_reason == exception.value
+        assert state_change.reason
+        assert state_change.reason.code == 40005
+        assert state_change.reason.status_code == 400
+        assert ably.connection.error_reason
+        assert ably.connection.error_reason.code == 40005
+        assert ably.connection.error_reason.status_code == 400
         await ably.close()
 
     async def test_connection_ping_connected(self):
         ably = await RestSetup.get_ably_realtime()
-        await ably.connect()
+        await ably.connection.once_async(ConnectionState.CONNECTED)
         response_time_ms = await ably.connection.ping()
         assert response_time_ms is not None
         assert type(response_time_ms) is float
@@ -62,10 +58,8 @@ class TestRealtimeConnection(BaseAsyncTestCase):
 
     async def test_connection_ping_failed(self):
         ably = await RestSetup.get_ably_realtime(key=self.valid_key_format)
-        with pytest.raises(AblyException) as exception:
-            await ably.connect()
+        await ably.connection.once_async(ConnectionState.FAILED)
         assert ably.connection.state == ConnectionState.FAILED
-        assert ably.connection.error_reason == exception.value
         with pytest.raises(AblyException) as exception:
             await ably.connection.ping()
         assert exception.value.code == 400
@@ -74,8 +68,8 @@ class TestRealtimeConnection(BaseAsyncTestCase):
 
     async def test_connection_ping_closed(self):
         ably = await RestSetup.get_ably_realtime()
-        await ably.connect()
-        assert ably.connection.state == ConnectionState.CONNECTED
+        ably.connect()
+        await ably.connection.once_async(ConnectionState.CONNECTED)
         await ably.close()
         with pytest.raises(AblyException) as exception:
             await ably.connection.ping()
@@ -108,175 +102,120 @@ class TestRealtimeConnection(BaseAsyncTestCase):
     async def test_connection_state_change_reason(self):
         ably = await RestSetup.get_ably_realtime(key=self.valid_key_format)
 
-        failed_changes = []
+        state_change = await ably.connection.once_async()
 
-        def on_state_change(change):
-            failed_changes.append(change)
-
-        ably.connection.on(ConnectionState.FAILED, on_state_change)
-
-        with pytest.raises(AblyException) as exception:
-            await ably.connect()
-
-        assert len(failed_changes) == 1
-        state_change = failed_changes[0]
-        assert state_change is not None
         assert state_change.previous == ConnectionState.CONNECTING
         assert state_change.current == ConnectionState.FAILED
-        assert state_change.reason == exception.value
-        assert ably.connection.error_reason == exception.value
+        assert ably.connection.error_reason is not None
+        assert ably.connection.error_reason is state_change.reason
         await ably.close()
 
     async def test_realtime_request_timeout_connect(self):
         ably = await RestSetup.get_ably_realtime(realtime_request_timeout=0.000001)
-        with pytest.raises(AblyException) as exception:
-            await ably.connect()
-        assert exception.value.code == 50003
-        assert exception.value.status_code == 504
+        state_change = await ably.connection.once_async()
+        assert state_change.reason is not None
+        assert state_change.reason.code == 50003
+        assert state_change.reason.status_code == 504
         assert ably.connection.state == ConnectionState.DISCONNECTED
-        assert ably.connection.error_reason == exception.value
+        assert ably.connection.error_reason == state_change.reason
         await ably.close()
 
     async def test_realtime_request_timeout_ping(self):
         ably = await RestSetup.get_ably_realtime(realtime_request_timeout=2000)
-        await ably.connect()
+        await ably.connection.once_async(ConnectionState.CONNECTED)
+
         original_send_protocol_message = ably.connection.connection_manager.send_protocol_message
 
         async def new_send_protocol_message(protocol_message):
             if protocol_message.get('action') == ProtocolMessageAction.HEARTBEAT:
                 return
             await original_send_protocol_message(protocol_message)
+
         ably.connection.connection_manager.send_protocol_message = new_send_protocol_message
 
         with pytest.raises(AblyException) as exception:
             await ably.connection.ping()
+
         assert exception.value.code == 50003
         assert exception.value.status_code == 504
         await ably.close()
 
-    async def test_realtime_request_timeout_close(self):
-        ably = await RestSetup.get_ably_realtime(realtime_request_timeout=2000)
-        await ably.connect()
-
-        async def new_close_transport():
-            pass
-
-        ably.connection.connection_manager.transport.close = new_close_transport
-
-        with pytest.raises(AblyException) as exception:
-            await ably.close()
-        assert exception.value.code == 50003
-        assert exception.value.status_code == 504
-
     async def test_disconnected_retry_timeout(self):
         ably = await RestSetup.get_ably_realtime(disconnected_retry_timeout=2000, auto_connect=False)
-        original_connect = ably.connection.connection_manager._connect
+        original_connect = ably.connection.connection_manager.connect_base
         call_count = 0
-        test_future = asyncio.Future()
-        test_exception = Exception()
 
         # intercept the library connection mechanism to fail the first two connection attempts
         async def new_connect():
             nonlocal call_count
             if call_count < 2:
+                ably.connection.connection_manager.notify_state(ConnectionState.DISCONNECTED)
                 call_count += 1
-                raise test_exception
             else:
                 await original_connect()
-                test_future.set_result(None)
 
-        ably.connection.connection_manager._connect = new_connect
+        ably.connection.connection_manager.connect_base = new_connect
 
-        with pytest.raises(Exception) as exception:
-            await ably.connect()
+        ably.connect()
 
-        assert ably.connection.state == ConnectionState.DISCONNECTED
-        assert exception.value == test_exception
+        await ably.connection.once_async(ConnectionState.DISCONNECTED)
 
-        await test_future
-
-        assert ably.connection.state == ConnectionState.CONNECTED
+        # Test that the library eventually connects after two failed attempts
+        await ably.connection.once_async(ConnectionState.CONNECTED)
 
         await ably.close()
 
     async def test_connectivity_check_default(self):
-        ably = await RestSetup.get_ably_realtime()
+        ably = await RestSetup.get_ably_realtime(auto_connect=False)
         # The default connectivity check should return True
         assert ably.connection.connection_manager.check_connection() is True
 
     async def test_connectivity_check_non_default(self):
         ably = await RestSetup.get_ably_realtime(
-            connectivity_check_url="https://echo.ably.io/respondWith?status=200")
+            connectivity_check_url="https://echo.ably.io/respondWith?status=200", auto_connect=False)
         # A non-default URL should return True with a HTTP OK despite not returning "Yes" in the body
         assert ably.connection.connection_manager.check_connection() is True
 
     async def test_connectivity_check_bad_status(self):
         ably = await RestSetup.get_ably_realtime(
-            connectivity_check_url="https://echo.ably.io/respondWith?status=400")
+            connectivity_check_url="https://echo.ably.io/respondWith?status=400", auto_connect=False)
         # Should return False when the URL returns a non-2xx response code
         assert ably.connection.connection_manager.check_connection() is False
 
-    async def test_retry_connection_attempt(self):
-        ably = await RestSetup.get_ably_realtime(
-            connectivity_check_url="https://echo.ably.io/respondWith?status=400", disconnected_retry_timeout=1,
-            auto_connect=False)
-        test_future = asyncio.Future()
-
-        def on_state_change(change):
-            if change.current == ConnectionState.DISCONNECTED:
-                test_future.set_result(change)
-
-        ably.connection.connection_manager.on('connectionstate', on_state_change)
-
-        asyncio.create_task(ably.connection.connection_manager.retry_connection_attempt())
-
-        state_change = await test_future
-
-        assert state_change.reason.status_code == 80003
-        assert state_change.reason.message == "Unable to connect (network unreachable)"
-
     async def test_unroutable_host(self):
-        ably = await RestSetup.get_ably_realtime(realtime_host="10.255.255.1")
-        with pytest.raises(AblyException) as exception:
-            await ably.connect()
-        assert exception.value.code == 50003
-        assert exception.value.status_code == 504
+        ably = await RestSetup.get_ably_realtime(realtime_host="10.255.255.1", realtime_request_timeout=3000)
+        state_change = await ably.connection.once_async()
+        assert state_change.reason
+        assert state_change.reason.code == 50003
+        assert state_change.reason.status_code == 504
         assert ably.connection.state == ConnectionState.DISCONNECTED
-        assert ably.connection.error_reason == exception.value
+        assert ably.connection.error_reason == state_change.reason
         await ably.close()
 
     async def test_invalid_host(self):
         ably = await RestSetup.get_ably_realtime(realtime_host="iamnotahost")
-        with pytest.raises(AblyException) as exception:
-            await ably.connect()
-        assert exception.value.code == 40000
-        assert exception.value.status_code == 400
+        state_change = await ably.connection.once_async()
+        assert state_change.reason
+        assert state_change.reason.code == 40000
+        assert state_change.reason.status_code == 400
         assert ably.connection.state == ConnectionState.DISCONNECTED
-        assert ably.connection.error_reason == exception.value
+        assert ably.connection.error_reason == state_change.reason
         await ably.close()
 
     async def test_connection_state_ttl(self):
-        Defaults.connection_state_ttl = 100
-        ably = await RestSetup.get_ably_realtime(realtime_host="iamnotahost")
-        changes = []
-        suspended_future = asyncio.Future()
+        Defaults.connection_state_ttl = 10
+        ably = await RestSetup.get_ably_realtime()
 
-        def on_state_change(state_change):
-            changes.append(state_change)
-            if state_change.current == ConnectionState.SUSPENDED:
-                suspended_future.set_result(None)
-        with pytest.raises(AblyException) as exception:
-            await ably.connect()
-        ably.connection.on(on_state_change)
-        assert exception.value.code == 40000
-        assert exception.value.status_code == 400
-        assert ably.connection.state == ConnectionState.DISCONNECTED
-        await suspended_future
-        assert ably.connection.state == changes[-1].current
-        assert ably.connection.state == ConnectionState.SUSPENDED
+        state_change = await ably.connection.once_async()
+
+        assert state_change.previous == ConnectionState.CONNECTING
+        assert state_change.current == ConnectionState.SUSPENDED
+        assert state_change.reason
+        assert state_change.reason.code == 80002
+        assert state_change.reason.status_code == 400
         assert ably.connection.connection_details is None
-        assert ably.connection.error_reason == changes[-1].reason
         await ably.close()
+
         Defaults.connection_state_ttl = 120000
 
     async def test_handle_connected(self):
@@ -304,8 +243,6 @@ class TestRealtimeConnection(BaseAsyncTestCase):
     async def test_max_idle_interval(self):
         ably = await RestSetup.get_ably_realtime(realtime_request_timeout=2000)
 
-        test_future = asyncio.Future()
-
         def on_transport_pending(transport):
             original_on_protocol_message = transport.on_protocol_message
 
@@ -319,12 +256,7 @@ class TestRealtimeConnection(BaseAsyncTestCase):
 
         ably.connection.connection_manager.on('transport.pending', on_transport_pending)
 
-        def once_disconnected(state_change):
-            test_future.set_result(state_change)
-
-        ably.connection.once(ConnectionState.DISCONNECTED, once_disconnected)
-
-        state_change = await test_future
+        state_change = await ably.connection.once_async(ConnectionState.DISCONNECTED)
 
         assert state_change.previous == ConnectionState.CONNECTED
         assert state_change.current == ConnectionState.DISCONNECTED

--- a/test/ably/realtimeinit_test.py
+++ b/test/ably/realtimeinit_test.py
@@ -31,7 +31,8 @@ class TestRealtimeInit(BaseAsyncTestCase):
     async def test_init_without_autoconnect(self):
         ably = await RestSetup.get_ably_realtime(auto_connect=False)
         assert ably.connection.state == ConnectionState.INITIALIZED
-        await ably.connect()
+        ably.connect()
+        await ably.connection.once_async(ConnectionState.CONNECTED)
         assert ably.connection.state == ConnectionState.CONNECTED
         await ably.close()
         assert ably.connection.state == ConnectionState.CLOSED


### PR DESCRIPTION
Resolves #413

Sorry in advance for 957e8f59911f5c798ec0bf1aad430005c13fa3b5. The commits leading up that are creating new methods to manage internal connection state, the key changes are:
- Adding `ConnectionManager.request_state`, used to add middleware to execute when the user calls certain methods like `connect`, and when an expiring timer wants the library to retry connection.
- Adding `ConnectionManager.notify_state`, used to add middleware to execute when a state change is triggered by a message from ably or an internal connection error.
- Moving internal timers and retry logic to the new `Timer` class, along with helper methods to ensure that timers are never duplicated.

 957e8f59911f5c798ec0bf1aad430005c13fa3b5 then changes the library to use these new methods internally, which obviously means rewriting basically all of the realtime tests, and also includes some lib changes to make some of the tests pass. On the bright side, after these changes we now have exactly zero warnings being emitted from the entire realtime test suite which is nice.