### PR TITLE
Refactor realtime channel

### DIFF
--- a/ably/realtime/realtime_channel.py
+++ b/ably/realtime/realtime_channel.py
@@ -107,7 +107,7 @@ class RealtimeChannel(EventEmitter, Channel):
                 raise AblyException("Unable to detach channel due to request timeout", 504, 50003)
             return
 
-        self._notify_state(ChannelState.ATTACHING)
+        self._request_state(ChannelState.ATTACHING)
 
         # RTL4i - wait for pending connection
         if self.__realtime.connection.state == ConnectionState.CONNECTING:
@@ -125,7 +125,7 @@ class RealtimeChannel(EventEmitter, Channel):
             await asyncio.wait_for(self.__attach_future, self.__timeout_in_secs)  # RTL4f
         except asyncio.TimeoutError:
             raise AblyException("Timeout waiting for channel attach", 504, 50003)
-        self._notify_state(ChannelState.ATTACHED)
+        self._request_state(ChannelState.ATTACHED)
 
     # RTL5
     async def detach(self):
@@ -323,6 +323,10 @@ class RealtimeChannel(EventEmitter, Channel):
             messages = Message.from_encoded_array(msg.get('messages'))
             for message in messages:
                 self.__message_emitter._emit(message.name, message)
+
+    def _request_state(self, state: ChannelState):
+        log.info(f'RealtimeChannel._request_state(): state = {state}')
+        self._notify_state(state)
 
     def _notify_state(self, state: ChannelState, reason=None):
         log.info(f'RealtimeChannel._notify_state(): state = {state}')

--- a/ably/realtime/realtime_channel.py
+++ b/ably/realtime/realtime_channel.py
@@ -114,13 +114,14 @@ class RealtimeChannel(EventEmitter, Channel):
             await self.__realtime.connect()
 
         self.__attach_future = asyncio.Future()
+
         # RTL4c
-        await self.__realtime.connection.connection_manager.send_protocol_message(
-            {
-                "action": ProtocolMessageAction.ATTACH,
-                "channel": self.name,
-            }
-        )
+        attach_msg = {
+            "action": ProtocolMessageAction.ATTACH,
+            "channel": self.name,
+        }
+        self._send_message(attach_msg)
+
         try:
             await asyncio.wait_for(self.__attach_future, self.__timeout_in_secs)  # RTL4f
         except asyncio.TimeoutError:
@@ -175,13 +176,14 @@ class RealtimeChannel(EventEmitter, Channel):
             await self.__realtime.connect()
 
         self.__detach_future = asyncio.Future()
+
         # RTL5d
-        await self.__realtime.connection.connection_manager.send_protocol_message(
-            {
-                "action": ProtocolMessageAction.DETACH,
-                "channel": self.name,
-            }
-        )
+        detach_msg = {
+            "action": ProtocolMessageAction.DETACH,
+            "channel": self.name,
+        }
+        self._send_message(detach_msg)
+
         try:
             await asyncio.wait_for(self.__detach_future, self.__timeout_in_secs)  # RTL5f
         except asyncio.TimeoutError:
@@ -338,6 +340,9 @@ class RealtimeChannel(EventEmitter, Channel):
 
         self.__state = state
         self._emit(state, state_change)
+
+    def _send_message(self, msg):
+        asyncio.create_task(self.__realtime.connection.connection_manager.send_protocol_message(msg))
 
     # RTL23
     @property

--- a/ably/realtime/realtime_channel.py
+++ b/ably/realtime/realtime_channel.py
@@ -19,6 +19,8 @@ class ChannelState(str, Enum):
     ATTACHED = 'attached'
     DETACHING = 'detaching'
     DETACHED = 'detached'
+    SUSPENDED = 'suspended'
+    FAILED = 'failed'
 
 
 class RealtimeChannel(EventEmitter, Channel):

--- a/ably/realtime/realtime_channel.py
+++ b/ably/realtime/realtime_channel.py
@@ -182,18 +182,24 @@ class RealtimeChannel(EventEmitter, Channel):
 
         self.__detach_future = asyncio.Future()
 
-        # RTL5d
-        detach_msg = {
-            "action": ProtocolMessageAction.DETACH,
-            "channel": self.name,
-        }
-        self._send_message(detach_msg)
+        self._detach_impl()
 
         try:
             await asyncio.wait_for(self.__detach_future, self.__timeout_in_secs)  # RTL5f
         except asyncio.TimeoutError:
             raise AblyException("Timeout waiting for channel detach", 504, 50003)
         self._notify_state(ChannelState.DETACHED)
+
+    def _detach_impl(self):
+        log.info("RealtimeChannel.detach_impl(): sending DETACH protocol message")
+
+        # RTL5d
+        detach_msg = {
+            "action": ProtocolMessageAction.DETACH,
+            "channel": self.__name,
+        }
+
+        self._send_message(detach_msg)
 
     # RTL7
     async def subscribe(self, *args):

--- a/ably/realtime/realtime_channel.py
+++ b/ably/realtime/realtime_channel.py
@@ -115,18 +115,23 @@ class RealtimeChannel(EventEmitter, Channel):
 
         self.__attach_future = asyncio.Future()
 
-        # RTL4c
-        attach_msg = {
-            "action": ProtocolMessageAction.ATTACH,
-            "channel": self.name,
-        }
-        self._send_message(attach_msg)
+        self._attach_impl()
 
         try:
             await asyncio.wait_for(self.__attach_future, self.__timeout_in_secs)  # RTL4f
         except asyncio.TimeoutError:
             raise AblyException("Timeout waiting for channel attach", 504, 50003)
         self._request_state(ChannelState.ATTACHED)
+
+    def _attach_impl(self):
+        log.info("RealtimeChannel.attach_impl(): sending ATTACH protocol message")
+
+        # RTL4c
+        attach_msg = {
+            "action": ProtocolMessageAction.ATTACH,
+            "channel": self.name,
+        }
+        self._send_message(attach_msg)
 
     # RTL5
     async def detach(self):

--- a/ably/realtime/realtime_channel.py
+++ b/ably/realtime/realtime_channel.py
@@ -1,5 +1,7 @@
 import asyncio
+from dataclasses import dataclass
 import logging
+from typing import Optional
 
 from ably.realtime.connection import ConnectionState, ProtocolMessageAction
 from ably.rest.channel import Channel
@@ -21,6 +23,13 @@ class ChannelState(str, Enum):
     DETACHED = 'detached'
     SUSPENDED = 'suspended'
     FAILED = 'failed'
+
+
+@dataclass
+class ChannelStateChange:
+    previous: ChannelState
+    current: ChannelState
+    reason: Optional[AblyException] = None
 
 
 class RealtimeChannel(EventEmitter, Channel):

--- a/test/ably/realtimechannel_test.py
+++ b/test/ably/realtimechannel_test.py
@@ -249,6 +249,6 @@ class TestRealtimeChannel(BaseAsyncTestCase):
         await channel.attach()
         with pytest.raises(AblyException) as exception:
             await channel.detach()
-        assert exception.value.code == 50003
-        assert exception.value.status_code == 504
+        assert exception.value.code == 90007
+        assert exception.value.status_code == 408
         await ably.close()

--- a/test/ably/realtimechannel_test.py
+++ b/test/ably/realtimechannel_test.py
@@ -230,8 +230,8 @@ class TestRealtimeChannel(BaseAsyncTestCase):
         channel = ably.channels.get('channel_name')
         with pytest.raises(AblyException) as exception:
             await channel.attach()
-        assert exception.value.code == 50003
-        assert exception.value.status_code == 504
+        assert exception.value.code == 90007
+        assert exception.value.status_code == 408
         await ably.close()
 
     async def test_realtime_request_timeout_detach(self):


### PR DESCRIPTION
Similar to #414, this PR refactors the internal state machine logic for realtime channel and resolves a few issues where channels would end up in invalid states. The main changes are:
- Moving state change logic into `request_state` and `notify_state` methods
- Using the `Timer` class to handle request timeouts