### PR TITLE
fix: use `httpx.Timeout` class to set http timeouts

### DIFF
--- a/ably/http/http.py
+++ b/ably/http/http.py
@@ -182,7 +182,7 @@ class Http:
         if headers:
             all_headers.update(headers)
 
-        timeout = (self.http_open_timeout, self.http_request_timeout)
+        timeout = httpx.Timeout(self.http_request_timeout, connect=self.http_open_timeout, pool=None)
         http_max_retry_duration = self.http_max_retry_duration
         requested_at = time.time()
 

--- a/test/ably/restrequest_test.py
+++ b/test/ably/restrequest_test.py
@@ -97,7 +97,7 @@ class TestRestRequest(BaseAsyncTestCase, metaclass=VaryByProtocolTestsMetaclass)
         timeout = 0.000001
         ably = AblyRest(token="foo", http_request_timeout=timeout)
         assert ably.http.http_request_timeout == timeout
-        with pytest.raises(httpx.ReadTimeout):
+        with pytest.raises(httpx.WriteTimeout):
             await ably.request('GET', '/time')
         await ably.close()
 


### PR DESCRIPTION
Opening as a draft for now because it's proving hard to write a test for this. Should hopefully make it so that fallback hosts are tried if an http request times out.