### PR TITLE
Pass clientId as query string param when opening a new connection

### DIFF
--- a/ably/rest/auth.py
+++ b/ably/rest/auth.py
@@ -76,16 +76,17 @@ class Auth:
                              "auth_callback, auth_url, key, token or a TokenDetail")
 
     async def get_auth_transport_param(self):
+        auth_credentials = {}
+        if self.__client_id:
+            auth_credentials["client_id"] = self.__client_id
         if self.__auth_mechanism == Auth.Method.BASIC:
             key_name = self.__auth_options.key_name
             key_secret = self.__auth_options.key_secret
-            return {"key": f"{key_name}:{key_secret}"}
+            auth_credentials["key"] = f"{key_name}:{key_secret}"
         elif self.__auth_mechanism == Auth.Method.TOKEN:
             token_details = await self._ensure_valid_auth_credentials()
-            auth_credentials = {"accessToken": token_details.token}
-            if token_details.client_id:
-                auth_credentials["client_id"] = token_details.client_id
-            return auth_credentials
+            auth_credentials["accessToken"] = token_details.token
+        return auth_credentials
 
     async def __authorize_when_necessary(self, token_params=None, auth_options=None, force=False):
         token_details = await self._ensure_valid_auth_credentials(token_params, auth_options, force)

--- a/ably/rest/auth.py
+++ b/ably/rest/auth.py
@@ -82,7 +82,10 @@ class Auth:
             return {"key": f"{key_name}:{key_secret}"}
         elif self.__auth_mechanism == Auth.Method.TOKEN:
             token_details = await self._ensure_valid_auth_credentials()
-            return {"accessToken": token_details.token}
+            auth_credentials = {"accessToken": token_details.token}
+            if token_details.client_id:
+                auth_credentials["client_id"] = token_details.client_id
+            return auth_credentials
 
     async def __authorize_when_necessary(self, token_params=None, auth_options=None, force=False):
         token_details = await self._ensure_valid_auth_credentials(token_params, auth_options, force)

--- a/ably/rest/auth.py
+++ b/ably/rest/auth.py
@@ -77,8 +77,8 @@ class Auth:
 
     async def get_auth_transport_param(self):
         auth_credentials = {}
-        if self.__client_id:
-            auth_credentials["client_id"] = self.__client_id
+        if self.auth_options.client_id:
+            auth_credentials["client_id"] = self.auth_options.client_id
         if self.__auth_mechanism == Auth.Method.BASIC:
             key_name = self.__auth_options.key_name
             key_secret = self.__auth_options.key_secret

--- a/test/ably/realtime/realtimeconnection_test.py
+++ b/test/ably/realtime/realtimeconnection_test.py
@@ -325,22 +325,7 @@ class TestRealtimeConnection(BaseAsyncTestCase):
         await ably.close()
 
     #  RTN2d
-    async def test_connection_client_id_query_params_using_token_auth(self):
-        rest = await TestApp.get_ably_rest()
-        client_id = 'test_client_id'
-
-        token_details = await rest.auth.request_token({"client_id": client_id})
-
-        realtime = await TestApp.get_ably_realtime(token_details=token_details)
-
-        await realtime.connection.once_async(ConnectionState.CONNECTED)
-        assert realtime.connection.connection_manager.transport.params["client_id"] == client_id
-        assert realtime.auth.client_id == client_id
-
-        await realtime.close()
-        await rest.close()
-
-    async def test_connection_null_client_id_query_params_using_token_auth(self):
+    async def test_connection_null_client_id_query_params(self):
         rest = await TestApp.get_ably_rest()
 
         token_details = await rest.auth.request_token()
@@ -354,7 +339,7 @@ class TestRealtimeConnection(BaseAsyncTestCase):
         await realtime.close()
         await rest.close()
 
-    async def test_connection_client_id_query_params_using_api_key(self):
+    async def test_connection_client_id_query_params(self):
         client_id = 'test_client_id'
 
         ably = await TestApp.get_ably_realtime(client_id=client_id)
@@ -363,13 +348,4 @@ class TestRealtimeConnection(BaseAsyncTestCase):
         assert ably.connection.connection_manager.transport.params["client_id"] == client_id
         assert ably.auth.client_id == client_id
 
-        await ably.close()
-
-    async def test_connection_null_client_id_query_params_using_api_key(self):
-
-        ably = await TestApp.get_ably_realtime()
-
-        await ably.connection.once_async(ConnectionState.CONNECTED)
-        assert ably.connection.connection_manager.transport.params.get("client_id") is None
-        assert ably.auth.client_id is None
         await ably.close()

--- a/test/ably/realtime/realtimeconnection_test.py
+++ b/test/ably/realtime/realtimeconnection_test.py
@@ -323,3 +323,33 @@ class TestRealtimeConnection(BaseAsyncTestCase):
         await ably.connection.once_async(ConnectionState.CONNECTED)
         assert ably.connection.connection_manager.transport.host == fallback_host
         await ably.close()
+
+    #  RTN2d
+    async def test_connection_client_id_query_params_using_token_auth(self):
+        rest = await TestApp.get_ably_rest()
+        client_id = 'test_client_id'
+
+        token_details = await rest.auth.request_token({"client_id": client_id})
+
+        realtime = await TestApp.get_ably_realtime(token_details=token_details)
+
+        await realtime.connection.once_async(ConnectionState.CONNECTED)
+        assert realtime.connection.connection_manager.transport.params["client_id"] == client_id
+        assert realtime.auth.client_id == client_id
+
+        await realtime.close()
+        await rest.close()
+
+    async def test_connection_null_client_id_query_params_using_token_auth(self):
+        rest = await TestApp.get_ably_rest()
+
+        token_details = await rest.auth.request_token()
+
+        realtime = await TestApp.get_ably_realtime(token_details=token_details)
+
+        await realtime.connection.once_async(ConnectionState.CONNECTED)
+        assert realtime.connection.connection_manager.transport.params.get("client_id") is None
+        assert realtime.auth.client_id is None
+
+        await realtime.close()
+        await rest.close()

--- a/test/ably/realtime/realtimeconnection_test.py
+++ b/test/ably/realtime/realtimeconnection_test.py
@@ -353,3 +353,23 @@ class TestRealtimeConnection(BaseAsyncTestCase):
 
         await realtime.close()
         await rest.close()
+
+    async def test_connection_client_id_query_params_using_api_key(self):
+        client_id = 'test_client_id'
+
+        ably = await TestApp.get_ably_realtime(client_id=client_id)
+
+        await ably.connection.once_async(ConnectionState.CONNECTED)
+        assert ably.connection.connection_manager.transport.params["client_id"] == client_id
+        assert ably.auth.client_id == client_id
+
+        await ably.close()
+
+    async def test_connection_null_client_id_query_params_using_api_key(self):
+
+        ably = await TestApp.get_ably_realtime()
+
+        await ably.connection.once_async(ConnectionState.CONNECTED)
+        assert ably.connection.connection_manager.transport.params.get("client_id") is None
+        assert ably.auth.client_id is None
+        await ably.close()


### PR DESCRIPTION
Resolves #449 