### PR TITLE
RTC4a: `Realtime.Auth.client_id` is `None` until connected

### DIFF
--- a/ably/realtime/realtime.py
+++ b/ably/realtime/realtime.py
@@ -91,9 +91,10 @@ class AblyRealtime(AblyRest):
             except RuntimeError:
                 log.warning('Realtime client created outside event loop')
 
+        self._is_realtime = True
+
         # RTC1
         super().__init__(key, loop=loop, **kwargs)
-        self._is_realtime = True
 
         self.key = key
         self.__connection = Connection(self)

--- a/ably/rest/rest.py
+++ b/ably/rest/rest.py
@@ -60,7 +60,10 @@ class AblyRest:
         else:
             options = Options(**kwargs)
 
-        self._is_realtime = False
+        try:
+            self._is_realtime
+        except AttributeError:
+            self._is_realtime = False
 
         self.__http = Http(self, options)
         self.__auth = Auth(self, options)

--- a/test/ably/realtime/realtimeauth_test.py
+++ b/test/ably/realtime/realtimeauth_test.py
@@ -600,6 +600,9 @@ class TestRealtimeAuth(BaseAsyncTestCase):
 
         realtime = await TestApp.get_ably_realtime(auth_callback=auth_callback)
 
+        # RTC4a
+        assert realtime.auth.client_id is None
+
         await realtime.connection.once_async(ConnectionState.CONNECTED)
 
         assert realtime.auth.client_id == client_id
@@ -618,6 +621,8 @@ class TestRealtimeAuth(BaseAsyncTestCase):
 
         realtime = await TestApp.get_ably_realtime(token_details=token_details, client_id="WRONG")
 
+        assert realtime.auth.client_id is None
+
         state_change = await realtime.connection.once_async(ConnectionState.FAILED)
 
         assert state_change.reason.code == 40102
@@ -635,6 +640,8 @@ class TestRealtimeAuth(BaseAsyncTestCase):
 
         realtime = await TestApp.get_ably_realtime(token_details=token_details, client_id=client_id)
 
+        assert realtime.auth.client_id is None
+
         await realtime.connection.once_async(ConnectionState.CONNECTED)
 
         assert realtime.auth.client_id == client_id
@@ -651,6 +658,8 @@ class TestRealtimeAuth(BaseAsyncTestCase):
         token_details = await rest.auth.request_token({"client_id": client_id})
 
         realtime = await TestApp.get_ably_realtime(token_details=token_details)
+
+        assert realtime.auth.client_id is None
 
         await realtime.connection.once_async(ConnectionState.CONNECTED)
 


### PR DESCRIPTION
Resolves #409