### PR TITLE
RSN4b Compliance

### DIFF
--- a/ably/rest/channel.py
+++ b/ably/rest/channel.py
@@ -221,6 +221,3 @@ class Channels:
 
     def release(self, key):
         del self.__all[key]
-
-    def __delitem__(self, key):
-        return self.release(key)

--- a/ably/rest/channel.py
+++ b/ably/rest/channel.py
@@ -219,7 +219,7 @@ class Channels:
     def __iter__(self) -> Iterator[str]:
         return iter(self.__all.values())
 
-    #RSN4
+    # RSN4
     def release(self, name):
         """Releases a Channel object, deleting it, and enabling it to be garbage collected.
         If the channel does not exist, nothing happens.

--- a/ably/rest/channel.py
+++ b/ably/rest/channel.py
@@ -219,5 +219,19 @@ class Channels:
     def __iter__(self) -> Iterator[str]:
         return iter(self.__all.values())
 
-    def release(self, key):
-        del self.__all[key]
+    #RSN4
+    def release(self, name):
+        """Releases a Channel object, deleting it, and enabling it to be garbage collected.
+        If the channel does not exist, nothing happens.
+
+        It also removes any listeners associated with the channel.
+
+        Parameters
+        ----------
+        name: str
+            Channel name
+        """
+
+        if name not in self.__all:
+            return
+        del self.__all[name]

--- a/test/ably/rest/restchannels_test.py
+++ b/test/ably/rest/restchannels_test.py
@@ -70,12 +70,11 @@ class TestChannels(BaseAsyncTestCase):
             assert isinstance(channel, Channel)
             assert name == channel.name
 
+    # RSN4a, RSN4b
     def test_channels_release(self):
         self.ably.channels.get('new_channel')
         self.ably.channels.release('new_channel')
-
-        with pytest.raises(KeyError):
-            self.ably.channels.release('new_channel')
+        self.ably.channels.release('new_channel')
 
     def test_channel_has_presence(self):
         channel = self.ably.channels.get('new_channnel')

--- a/test/ably/rest/restchannels_test.py
+++ b/test/ably/rest/restchannels_test.py
@@ -77,13 +77,6 @@ class TestChannels(BaseAsyncTestCase):
         with pytest.raises(KeyError):
             self.ably.channels.release('new_channel')
 
-    def test_channels_del(self):
-        self.ably.channels.get('new_channel')
-        del self.ably.channels['new_channel']
-
-        with pytest.raises(KeyError):
-            del self.ably.channels['new_channel']
-
     def test_channel_has_presence(self):
         channel = self.ably.channels.get('new_channnel')
         assert channel.presence


### PR DESCRIPTION
This change does the following:

- Removes the `__delitem__` magic method from the REST `Channels` implementation (as not part of spec)
- Fixes a non-compliance with `RSN4b` - whereby previously calling release on a non-existent channel would result in a KeyError being raised.

Fixes #472 