### PR TITLE
Remove unused dependency: h2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -258,6 +258,7 @@ files = [
 
 [package.dependencies]
 certifi = "*"
+h2 = {version = ">=3,<5", optional = true, markers = "extra == \"http2\""}
 httpcore = ">=0.15.0,<0.18.0"
 idna = "*"
 sniffio = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ python = "^3.7"
 # Mandatory dependencies
 methoddispatch = "^3.0.2"
 msgpack = "^1.0.0"
-httpx[http2] = "^0.24.1"
+httpx = { version = "^0.24.1", extras = ["http2"] }
 
 # Optional dependencies
 pycrypto = { version = "^2.6.1", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ python = "^3.7"
 # Mandatory dependencies
 methoddispatch = "^3.0.2"
 msgpack = "^1.0.0"
-httpx = "^0.24.1"
+httpx[http2] = "^0.24.1"
 
 # Optional dependencies
 pycrypto = { version = "^2.6.1", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ python = "^3.7"
 methoddispatch = "^3.0.2"
 msgpack = "^1.0.0"
 httpx = "^0.24.1"
-h2 = "^4.0.0"
 
 # Optional dependencies
 pycrypto = { version = "^2.6.1", optional = true }


### PR DESCRIPTION
## Summary

This pull request removes the unused dependency `h2` from the `pyproject.toml` configuration file. The removal of this dependency is a finding from ongoing research aimed at identifying and eliminating code bloat within software projects.

## Rationale

The `h2` dependency was introduced in the project in fc150960 but it was never directly invoked on the source code, serving only as a transitive dependency.
Removing this unused dependency contributes to a leaner codebase, reduces security risks, and simplifies dependency management.
## Changes

- Removed the `h2` dependency from `pyproject.toml`

## Impact

- Enhanced project maintainability


