### PR TITLE
Update README.md to add in 'publish message to channel including metadata'

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ logger.addHandler(logging.StreamHandler())
 await channel.publish('event', 'message')
 ```
 
+### Publishing a message to a channel including metadata
+
+```python
+from ably.types.message import Message
+messageObject = Message(name="messagename",
+                        data="payload",
+                        extras={"headers": {"metadataKey": "metadataValue"}})
+await channel.publish(messageObject)
+```
+
 ### Querying the History
 
 ```python


### PR DESCRIPTION
Add in 'publish message to channel including metadata', i.e. in the extras headers json, which I believe has to be done through calling the Message constructor.