### PR TITLE
Simplify upgrade section in the readme as currently it is talking about breaking changes in v1.2 (and there already was v2 with additional changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cd ably-python
 python setup.py install
 ```
 
-## Upgrad / Migration Guide
+## Upgrade / Migration Guide
 
 Please see our [Upgrade / Migration Guide](UPDATING.md) for notes on changes you need to make to your code to update it to use the new APIs when migrating from older versions.
 


### PR DESCRIPTION
As you can see here https://github.com/ably/ably-python?tab=readme-ov-file#breaking-api-changes-in-version-120 there is a whole section in the Readme related to changes in the version 1.2. However, there already was another major version release since then. 

This can be a bit confusing, and as we list all breaking changes in [Migration Guide](https://github.com/ably/ably-python/blob/main/UPDATING.md). This PR suggests a simpler readme section that just points to the migration guide. 