### PR TITLE
test: Don't assert error messages

### DIFF
--- a/test/ably/rest/restchannels_test.py
+++ b/test/ably/rest/restchannels_test.py
@@ -87,5 +87,5 @@ class TestChannels(BaseAsyncTestCase):
         with pytest.raises(AblyException) as excinfo:
             await ably.channels['test_publish_without_permission'].publish('foo', 'woop')
 
-        assert 'not permitted' in excinfo.value.message
+        assert 40160 == excinfo.value.code
         await ably.close()


### PR DESCRIPTION
They are subject to change, so checking the error code is enough to know that the expected error occurred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated the assertion in the `test_without_permissions` function to validate error codes instead of exception message content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->