### PR TITLE
Fix `TypeError: '>' not supported between instances of 'float' and 'NoneType'` in http

### DIFF
--- a/ably/http/http.py
+++ b/ably/http/http.py
@@ -146,7 +146,8 @@ class Http:
         if host is None:
             return hosts
 
-        if time.time() > self.__host_expires:
+        # unstore saved fallback host after fallbackRetryTimeout (RSC15f)
+        if self.__host_expires is not None and time.time() > self.__host_expires:
             self.__host = None
             self.__host_expires = None
             return hosts

--- a/test/unit/http_test.py
+++ b/test/unit/http_test.py
@@ -1,0 +1,19 @@
+from ably import AblyRest
+
+
+def test_http_get_rest_hosts_works_when_fallback_realtime_host_is_set():
+    ably = AblyRest(token="foo")
+    ably.options.fallback_realtime_host = ably.options.get_rest_hosts()[0]
+    # Should not raise TypeError
+    hosts = ably.http.get_rest_hosts()
+    assert isinstance(hosts, list)
+    assert all(isinstance(host, str) for host in hosts)
+
+
+def test_http_get_rest_hosts_works_when_fallback_realtime_host_is_not_set():
+    ably = AblyRest(token="foo")
+    ably.options.fallback_realtime_host = None
+    # Should not raise TypeError
+    hosts = ably.http.get_rest_hosts()
+    assert isinstance(hosts, list)
+    assert all(isinstance(host, str) for host in hosts)


### PR DESCRIPTION
See internal slack discussion for errors received by a client: https://ably-real-time.slack.com/archives/CURL4U2FP/p1735900004756929.

Fixes the race condition error in `http.get_rest_hosts` when `options.fallback_realtime_host` is set.
You can see the error being reproduced in CI in this run: https://github.com/ably/ably-python/actions/runs/12692221157/job/35377048528?pr=573

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added two new test cases to verify the behavior of REST host retrieval under different fallback host configurations.
	- Ensures proper functionality of host retrieval with and without a fallback realtime host.

- **Bug Fixes**
	- Improved host expiration logic to clarify checks for valid expiration time before evaluating host expiration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->