### PR TITLE
[ECO-5217] Update `pyee` version dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -912,4 +912,4 @@ oldcrypto = ["pycrypto"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "afa63444ccd8197c15f29772eb3807f8d1e03c7aed7562c84d1087d16853bd24"
+content-hash = "b7e8dc197cd44303a87a1abb4b0657313329517066a7add173c257ec2d4be673"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ h2 = "^4.1.0" # required for httx package, HTTP2 communication
 websockets = ">= 10.0, < 13.0"
 pyee = [
   { version = "^9.0.4", python = "~3.7" },
-  { version = "^11.1.0", python = "^3.8" }
+  { version = ">=11.1.0, <13.0.0", python = "^3.8" }
 ]
 
 # Optional dependencies


### PR DESCRIPTION
Based on `pyee` changelog there are no breaking changes in version 12 that affect us: https://github.com/jfhbrook/pyee/blob/main/CHANGELOG.md.
I've forced pyee@12 in a draft https://github.com/ably/ably-python/pull/581 PR to run tests with it. Encountered same errors as the last time the release was made in https://github.com/ably/ably-python/pull/576.

(update: fixed tests failinig due to credentials error code in https://github.com/ably/ably-python/pull/583)

Resolves #580 