### PR TITLE
Update error code for invalid credentials in tests

### DIFF
--- a/test/ably/realtime/realtimeauth_test.py
+++ b/test/ably/realtime/realtimeauth_test.py
@@ -45,8 +45,8 @@ class TestRealtimeAuth(BaseAsyncTestCase):
         ably = await TestApp.get_ably_realtime(key=api_key)
         state_change = await ably.connection.once_async(ConnectionState.FAILED)
         assert ably.connection.error_reason == state_change.reason
-        assert state_change.reason.code == 40005
-        assert state_change.reason.status_code == 400
+        assert state_change.reason.code == 40101
+        assert state_change.reason.status_code == 401
         await ably.close()
 
     async def test_auth_with_token_string(self):
@@ -63,8 +63,8 @@ class TestRealtimeAuth(BaseAsyncTestCase):
         invalid_token = "Sdnurv_some_invalid_token_nkds9r7"
         ably = await TestApp.get_ably_realtime(token=invalid_token)
         state_change = await ably.connection.once_async(ConnectionState.FAILED)
-        assert state_change.reason.code == 40005
-        assert state_change.reason.status_code == 400
+        assert state_change.reason.code == 40101
+        assert state_change.reason.status_code == 401
         await ably.close()
 
     async def test_auth_with_token_details(self):
@@ -81,8 +81,8 @@ class TestRealtimeAuth(BaseAsyncTestCase):
         invalid_token_details = TokenDetails(token="invalid-token")
         ably = await TestApp.get_ably_realtime(token_details=invalid_token_details)
         state_change = await ably.connection.once_async(ConnectionState.FAILED)
-        assert state_change.reason.code == 40005
-        assert state_change.reason.status_code == 400
+        assert state_change.reason.code == 40101
+        assert state_change.reason.status_code == 401
         await ably.close()
 
     async def test_auth_with_auth_callback_with_token_request(self):
@@ -133,8 +133,8 @@ class TestRealtimeAuth(BaseAsyncTestCase):
 
         ably = await TestApp.get_ably_realtime(auth_callback=callback)
         state_change = await ably.connection.once_async(ConnectionState.FAILED)
-        assert state_change.reason.code == 40005
-        assert state_change.reason.status_code == 400
+        assert state_change.reason.code == 40101
+        assert state_change.reason.status_code == 401
         await ably.close()
 
     async def test_auth_with_auth_url_json(self):

--- a/test/ably/realtime/realtimeconnection_test.py
+++ b/test/ably/realtime/realtimeconnection_test.py
@@ -34,11 +34,11 @@ class TestRealtimeConnection(BaseAsyncTestCase):
         state_change = await ably.connection.once_async()
         assert ably.connection.state == ConnectionState.FAILED
         assert state_change.reason
-        assert state_change.reason.code == 40005
-        assert state_change.reason.status_code == 400
+        assert state_change.reason.code == 40101
+        assert state_change.reason.status_code == 401
         assert ably.connection.error_reason
-        assert ably.connection.error_reason.code == 40005
-        assert ably.connection.error_reason.status_code == 400
+        assert ably.connection.error_reason.code == 40101
+        assert ably.connection.error_reason.status_code == 401
         await ably.close()
 
     async def test_connection_ping_connected(self):

--- a/test/ably/realtime/realtimeresume_test.py
+++ b/test/ably/realtime/realtimeresume_test.py
@@ -52,8 +52,8 @@ class TestRealtimeResume(BaseAsyncTestCase):
         ably.connection.connection_manager.notify_state(ConnectionState.DISCONNECTED)
 
         state_change = await ably.connection.once_async(ConnectionState.FAILED)
-        assert state_change.reason.code == 40005
-        assert state_change.reason.status_code == 400
+        assert state_change.reason.code == 40101
+        assert state_change.reason.status_code == 401
         await ably.close()
 
     # RTN15c7 - invalid resume response


### PR DESCRIPTION
See [internal slack thread](https://ably-real-time.slack.com/archives/CURL4U2FP/p1736356509105489) about the realtime update that changed the expected error code. Similar update made in `ably-cocoa`: https://github.com/ably/ably-cocoa/pull/2006/files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated error responses to provide clearer feedback during authentication and connection errors, ensuring that invalid API keys and tokens are classified with a more specific error code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->