### PR TITLE
Release 2.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [v2.0.9](https://github.com/ably/ably-python/tree/v2.0.9)
+
+[Full Changelog](https://github.com/ably/ably-python/compare/v2.0.8...v2.0.9)
+
+**Fixed bugs:**
+
+- Fix the inability to pass a JSON string value for a `capability` parameter when creating a token [\#579](https://github.com/ably/ably-python/issues/579)
+
+**Closed issues:**
+- Support `pyee` 12 [\#580](https://github.com/ably/ably-python/issues/580)
+
 ## [v2.0.8](https://github.com/ably/ably-python/tree/v2.0.8)
 
 [Full Changelog](https://github.com/ably/ably-python/compare/v2.0.7...v2.0.8)

--- a/ably/__init__.py
+++ b/ably/__init__.py
@@ -15,4 +15,4 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 api_version = '3'
-lib_version = '2.0.8'
+lib_version = '2.0.9'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ably"
-version = "2.0.8"
+version = "2.0.9"
 description = "Python REST and Realtime client library SDK for Ably realtime messaging service"
 license = "Apache-2.0"
 authors = ["Ably <support@ably.com>"]


### PR DESCRIPTION
- Support `pyee` 12 [\#580](https://github.com/ably/ably-python/issues/580)
- Fix the inability to pass a JSON string value for a `capability` parameter when creating a token [\#579](https://github.com/ably/ably-python/issues/579)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Released version 2.0.9, updating overall version information.

- **Bug Fixes**
  - Enhanced compatibility with a newer dependency version.
  - Fixed an issue that prevented using JSON string values for token capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->