### PR TITLE
Fix ably-python version regexp in `test_request_headers` test

### DIFF
--- a/test/ably/rest/resthttp_test.py
+++ b/test/ably/rest/resthttp_test.py
@@ -192,7 +192,7 @@ class TestRestHttp(BaseAsyncTestCase):
 
         # Agent
         assert 'Ably-Agent' in r.request.headers
-        expr = r"^ably-python\/\d.\d.\d(-beta\.\d)? python\/\d.\d+.\d+$"
+        expr = r"^ably-python\/\d+.\d+.\d+(-beta\.\d+)? python\/\d.\d+.\d+$"
         assert re.search(expr, r.request.headers['Ably-Agent'])
         await ably.close()
 


### PR DESCRIPTION
It didn't account that ably-python versions can have multiple digits for major/minor/patch parts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Refined the version number validation, improving flexibility to support multi-digit version segments in header checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->