### PR TITLE
[ECO-5220] Enforce `ubuntu-22.04` in CI to support python 3.7

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   check:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
python 3.7 has reached its end of life [1] and is no longer available for the current latest ubuntu version 24.04 [2], hence the "Version 3.7 was not found in the local cache" error in CI.

Enforce ubuntu-22.04 instead of ubuntu-latest so we can test against python 3.7 until we drop support for it in the library.

Resolves #585

[1] https://docs.python.org/3.7/whatsnew/3.7.0.html#summary
[2] https://github.com/actions/setup-python/issues/962#issuecomment-2414418045

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the build pipeline configuration to ensure more reliable and consistent deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->