### PR TITLE
Adds python 3.13 to the list of classifiers in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 include = [


### PR DESCRIPTION
This should've been updated as part of the [1] when added python 3.13 to CI.

[1] https://github.com/ably/ably-python/pull/584/files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded compatibility information to support Python 3.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->