### PR TITLE
Remove await from non async connect() function call

### DIFF
--- a/ably/realtime/realtime_channel.py
+++ b/ably/realtime/realtime_channel.py
@@ -156,7 +156,7 @@ class RealtimeChannel(EventEmitter, Channel):
 
         # RTL5h - wait for pending connection
         if self.__realtime.connection.state == ConnectionState.CONNECTING:
-            await self.__realtime.connect()
+            self.__realtime.connect()
 
         state_change = await self.__internal_state_emitter.once_async()
         new_state = state_change.current


### PR DESCRIPTION
Issue: https://github.com/ably/ably-python/issues/604

If the client state is connecting while in detach(), this block of code gets called

https://github.com/ably/ably-python/blob/3888f52b27f1f2e5142ca4f9727ae9f8b8722416/ably/realtime/realtime_channel.py#L159
```
  # RTL5h - wait for pending connection
        if self.__realtime.connection.state == ConnectionState.CONNECTING:
            await self.__realtime.connect()
```

Leading to the following error
```
File "/usr/local/lib/python3.11/site-packages/ably/realtime/realtime_channel.py", line 159,
  in detach
    await self.__realtime.connect()
TypeError: object NoneType can't be used in 'await' expression
```

I believe because connect is not async()
https://github.com/ably/ably-python/blob/3888f52b27f1f2e5142ca4f9727ae9f8b8722416/ably/realtime/realtime.py#L108

┆Issue is synchronized with this [Jira Task](https://ably.atlassian.net/browse/ECO-5499) by [Unito](https://www.unito.io)