### PR TITLE
Adds SDK setup link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Find out more:
 Everything you need to get started with Ably:
 
 * [Getting started with Pub/Sub using Python.](https://ably.com/docs/getting-started/python)
+* [SDK Setup for Python.](https://ably.com/docs/getting-started/setup?lang=python)
 
 ---
 


### PR DESCRIPTION
This PR:

- Adds "SDK setup link" for consistency with other readmes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “SDK Setup for Python” link under the Getting started section, placed after the existing Pub/Sub with Python guide to direct users to setup instructions.
  * Improves onboarding clarity for Python developers by separating environment setup from the Pub/Sub tutorial.
  * Enhances discoverability of Python setup resources.
  * No code, API, or runtime behavior changes, and no modifications to exported or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->