### PR TITLE
Release/2.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,16 +70,22 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
       - name: Extract tag
         id: tag
         run: |
           TAG=${GITHUB_REF#refs/tags/v}
           echo "tag=$TAG" >> $GITHUB_OUTPUT
 
-      - name: Read VERSION_NAME from pyproject.toml
+      - name: Read VERSION_NAME from dist/
         id: version
         run: |
-          VERSION_NAME=$(grep '^version' pyproject.toml | cut -d'=' -f2 | tr -d '[:space:]')
+          VERSION_NAME=$(basename dist/ably-*.tar.gz | sed -E 's/^ably-([^-]+)\.tar\.gz$/\1/')
           echo "version=$VERSION_NAME" >> $GITHUB_OUTPUT
 
       - name: Compare version with tag
@@ -91,11 +97,7 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
           TAG: ${{ steps.tag.outputs.tag }}
-      - name: Download all the dists
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
+
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
@@ -107,7 +109,7 @@ jobs:
 
     environment:
       name: testpypi
-      url: https://test.pypi.org/p/ably-dev
+      url: https://test.pypi.org/p/ably
 
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [v2.1.0](https://github.com/ably/ably-python/tree/v2.1.0)
+
+[Full Changelog](https://github.com/ably/ably-python/compare/v2.0.13...v2.1.0)
+
+## What's Changed
+
+* Added support for VCDiff delta-compressed messages. If VCDiff compression is enabled in the client options, and 
+deltas are provided by the Ably service, the SDK reconstructs full message payloads from the base content 
+and the received delta, reducing bandwidth usage without requiring changes to your application code.
+[\#620](https://github.com/ably/ably-python/pull/620)
+
 ## [v2.0.13](https://github.com/ably/ably-python/tree/v2.0.13)
 
 [Full Changelog](https://github.com/ably/ably-python/compare/v2.0.12...v2.0.13)

--- a/ably/__init__.py
+++ b/ably/__init__.py
@@ -16,4 +16,4 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 api_version = '3'
-lib_version = '2.0.13'
+lib_version = '2.1.0'

--- a/poetry.lock
+++ b/poetry.lock
@@ -884,13 +884,13 @@ files = [
 
 [[package]]
 name = "vcdiff-decoder"
-version = "0.1.0a1"
+version = "0.1.0"
 description = "Python implementation of VCDIFF (RFC 3284) delta compression format"
 optional = false
 python-versions = "<4.0,>=3.7"
 files = [
-    {file = "vcdiff_decoder-0.1.0a1-py3-none-any.whl", hash = "sha256:5d33ac9d2e7dfc141bcbf75b59a31f3b9e9cce59e92169995831f128be63d87d"},
-    {file = "vcdiff_decoder-0.1.0a1.tar.gz", hash = "sha256:734a181bae80ad9b44570e0905106dffc847e2351f8c8ffe7cc58c5c79c7890b"},
+    {file = "vcdiff_decoder-0.1.0-py3-none-any.whl", hash = "sha256:42f4e3d77b3bd4be881853858ee471a11d6a474fda375482d589b8576b91318f"},
+    {file = "vcdiff_decoder-0.1.0.tar.gz", hash = "sha256:905d9c39fd451331301652c16b19505c16d323446fa4dffa745b2855aff5fe69"},
 ]
 
 [[package]]
@@ -1168,4 +1168,4 @@ vcdiff = ["vcdiff-decoder"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "37f7bab9bd673078d3d7362dff9b9fcd5a515867725b68138a4dff5ee1f45204"
+content-hash = "ce837d7ac901ef173e8cc1077da2342e6335769cb5a65c84015564efe9c9b6bf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ably"
-version = "2.0.13"
+version = "2.1.0"
 description = "Python REST and Realtime client library SDK for Ably realtime messaging service"
 license = "Apache-2.0"
 authors = ["Ably <support@ably.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ pyee = [
 # Optional dependencies
 pycrypto = { version = "^2.6.1", optional = true }
 pycryptodome = { version = "*", optional = true }
-vcdiff-decoder = { version = "^0.1.0a1", optional = true }
+vcdiff-decoder = { version = "^0.1.0", optional = true }
 
 [tool.poetry.extras]
 oldcrypto = ["pycrypto"]


### PR DESCRIPTION
[Full Changelog](https://github.com/ably/ably-python/compare/v2.0.13...v2.1.0)

## What's Changed

* Added support for VCDIFF delta-compressed messages. When deltas are provided by the service, 
the SDK reconstructs full message payloads from the base content and the received delta, 
reducing bandwidth usage without changing your application code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support for VCDIFF delta-compressed messages: SDK can reconstruct full payloads from base+delta to reduce bandwidth without app changes.
- Documentation
  - Added v2.1.0 entry to the changelog with release links and a Full Changelog reference.
- Chores
  - Bumped package and public library version to 2.1.0, updated optional vcdiff-decoder dependency, and adjusted the release/publishing workflow steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->