### PR TITLE
Upgrade pyee to ^13 for python 3.8+

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -687,22 +687,22 @@ typing-extensions = "*"
 
 [[package]]
 name = "pyee"
-version = "12.1.1"
+version = "13.0.0"
 description = "A rough port of Node.js's EventEmitter to Python with a few tricks of its own"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "python_version >= \"3.8\""
 files = [
-    {file = "pyee-12.1.1-py3-none-any.whl", hash = "sha256:18a19c650556bb6b32b406d7f017c8f513aceed1ef7ca618fb65de7bd2d347ef"},
-    {file = "pyee-12.1.1.tar.gz", hash = "sha256:bbc33c09e2ff827f74191e3e5bbc6be7da02f627b7ec30d86f5ce1a6fb2424a3"},
+    {file = "pyee-13.0.0-py3-none-any.whl", hash = "sha256:48195a3cddb3b1515ce0695ed76036b5ccc2ef3a9f963ff9f77aec0139845498"},
+    {file = "pyee-13.0.0.tar.gz", hash = "sha256:b391e3c5a434d1f5118a25615001dbc8f669cf410ab67d04c4d4e07c55481c37"},
 ]
 
 [package.dependencies]
 typing-extensions = "*"
 
 [package.extras]
-dev = ["black", "build", "flake8", "flake8-black", "isort", "jupyter-console", "mkdocs", "mkdocs-include-markdown-plugin", "mkdocstrings[python]", "pytest", "pytest-asyncio ; python_version >= \"3.4\"", "pytest-trio ; python_version >= \"3.7\"", "sphinx", "toml", "tox", "trio", "trio ; python_version > \"3.6\"", "trio-typing ; python_version > \"3.6\"", "twine", "twisted", "validate-pyproject[all]"]
+dev = ["black", "build", "flake8", "flake8-black", "isort", "jupyter-console", "mkdocs", "mkdocs-include-markdown-plugin", "mkdocstrings[python]", "mypy", "pytest", "pytest-asyncio ; python_version >= \"3.4\"", "pytest-trio ; python_version >= \"3.7\"", "sphinx", "toml", "tox", "trio", "trio ; python_version > \"3.6\"", "trio-typing ; python_version > \"3.6\"", "twine", "twisted", "validate-pyproject[all]"]
 
 [[package]]
 name = "pyflakes"
@@ -1247,4 +1247,4 @@ vcdiff = ["vcdiff-decoder"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.7"
-content-hash = "fbad8755086c759d0d2d0ebbac45892627d3a43ad3f91a4782cda7fd9a8ba552"
+content-hash = "3a940983ed78d6a830e1c9179eedaf2063dc58cc1fb882ab8a72a9d9be8ab903"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ websockets = [
 ]
 pyee = [
   { version = "^9.0.4", python = "~3.7" },
-  { version = ">=11.1.0, <13.0.0", python = "^3.8" }
+  { version = ">=11.1.0, <14.0.0", python = "^3.8" }
 ]
 
 # Optional dependencies


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened a dependency version constraint to allow newer releases, improving compatibility and access to subsequent package updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->