### PR TITLE
fix: packaging issue for generated `/sync` files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
           if unzip -l "$WHEEL" | grep -q "ably/sync/"; then
             echo "✅ Found ably/sync/ in wheel"
           else
+            unzip -l "$WHEEL" 
             echo "❌ ably/sync/ not found in wheel"
             exit 1
           fi
@@ -62,6 +63,7 @@ jobs:
           if tar -tzf "$TARBALL" | grep -q "ably/sync/"; then
             echo "✅ Found ably/sync/ in tarball"
           else
+            tar -tzf "$TARBALL"
             echo "❌ ably/sync/ not found in tarball"
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,5 @@ ably/types/options.py.orig
 test/ably/restsetup.py.orig
 
 .idea/**/*
-**/ably/sync/***
+ably/sync/**
+test/ably/sync/**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,25 @@ Repository = "https://github.com/ably/ably-python"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+ignore-vcs = true
+include = [
+    "/ably",
+    "/COPYRIGHT",
+    "/README.md",
+    "/LICENSE",
+    "/LONG_DESCRIPTION.rst",
+    "/images",
+    "/setup.cfg",
+    "/pyproject.toml"
+]
+exclude = [
+    "**/*.pyc",
+    "**/__pycache__"
+]
+
 [tool.hatch.build.targets.wheel]
+ignore-vcs = true
 packages = ["ably"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
UV respects `.gitgnore` by default and excludes generated `/sync` files from built packages.

In this PR we explicitly specify files that should be packed and ignore vcs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced source-distribution packaging with explicit include/exclude controls and VCS-ignoring for more precise builds.
  * Narrowed repository ignore patterns to target specific paths instead of broad recursive patterns.
  * Improved release workflow diagnostics to list archive contents when expected files are missing, aiding failure investigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->