### PR TITLE
fix: fallback to type name in `from_exception` when exception has no message

### DIFF
--- a/ably/util/exceptions.py
+++ b/ably/util/exceptions.py
@@ -77,7 +77,13 @@ class AblyException(Exception):
     def from_exception(e):
         if isinstance(e, AblyException):
             return e
-        return AblyException(f"Unexpected exception: {e}", 500, 50000)
+        exc_type = type(e).__name__
+        exc_msg = str(e)
+        if exc_msg:
+            message = f"{exc_type}: {exc_msg}"
+        else:
+            message = exc_type
+        return AblyException(f"Unexpected exception: {message}", 500, 50000)
 
     @staticmethod
     def from_dict(value: dict):


### PR DESCRIPTION
httpx errors for example have no message so a http open timeout in `rest.time()` would result in an error message of "Unexpected exception:"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error message handling to include exception type information, providing more detailed diagnostics when unexpected exceptions occur.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->