### PR TITLE
fix: make `queueMessages` client option True by default

### DIFF
--- a/ably/realtime/realtime_channel.py
+++ b/ably/realtime/realtime_channel.py
@@ -498,6 +498,7 @@ class RealtimeChannel(EventEmitter, Channel):
         # RTL6c4: Check connection state
         connection_state = self.__realtime.connection.state
         if connection_state not in [
+            ConnectionState.INITIALIZED,
             ConnectionState.CONNECTED,
             ConnectionState.CONNECTING,
             ConnectionState.DISCONNECTED,

--- a/ably/types/options.py
+++ b/ably/types/options.py
@@ -26,7 +26,7 @@ class VCDiffDecoder(ABC):
 
 class Options(AuthOptions):
     def __init__(self, client_id=None, log_level=0, tls=True, rest_host=None, realtime_host=None, port=0,
-                 tls_port=0, use_binary_protocol=True, queue_messages=False, recover=False, environment=None,
+                 tls_port=0, use_binary_protocol=True, queue_messages=True, recover=False, environment=None,
                  http_open_timeout=None, http_request_timeout=None, realtime_request_timeout=None,
                  http_max_retry_count=None, http_max_retry_duration=None, fallback_hosts=None,
                  fallback_retry_timeout=None, disconnected_retry_timeout=None, idempotent_rest_publishing=None,

--- a/test/ably/realtime/realtimechannel_publish_test.py
+++ b/test/ably/realtime/realtimechannel_publish_test.py
@@ -285,6 +285,27 @@ class TestRealtimeChannelPublish(BaseAsyncTestCase):
 
         await ably.close()
 
+    async def test_publish_fails_on_initialized_when_queue_messages_false(self):
+        """RTN7d: Verify publish fails immediately when connection is CONNECTING and queueMessages=false"""
+        # Create client with queueMessages=False
+        ably = await TestApp.get_ably_realtime(
+            use_binary_protocol=self.use_binary_protocol,
+            queue_messages=False,
+            auto_connect=False
+        )
+
+        channel = ably.channels.get('test_initialized_channel')
+
+        # Try to publish while in the INITIALIZED state with queueMessages=false
+        with pytest.raises(AblyException) as exc_info:
+            await channel.publish('test_event', 'test_data')
+
+        # Verify it failed with appropriate error
+        assert exc_info.value.code == 90000
+        assert exc_info.value.status_code == 400
+
+        await ably.close()
+
     # RTN19a2 - Reset msgSerial on new connectionId
     async def test_msgserial_resets_on_new_connection_id(self):
         """RTN19a2: Verify msgSerial resets to 0 when connectionId changes"""

--- a/test/ably/realtime/realtimeconnection_test.py
+++ b/test/ably/realtime/realtimeconnection_test.py
@@ -460,3 +460,12 @@ class TestRealtimeConnection(BaseAsyncTestCase):
         assert all(isinstance(frame, str) for frame in received_raw_websocket_frames)
 
         await ably.close()
+
+    # TO3g
+    async def test_queue_messages_defaults_to_true(self):
+        """TO3g: Verify that queueMessages client option defaults to true"""
+        ably = await TestApp.get_ably_realtime(auto_connect=False)
+
+        # TO3g: queueMessages defaults to true
+        assert ably.options.queue_messages is True
+        assert ably.connection.connection_manager.options.queue_messages is True


### PR DESCRIPTION
 Make `queueMessages` client option True by default
 
  - Add TO3g test verifying queueMessages defaults to true
  - Add RTL6c2 check to fail immediately when queueMessages is false and connection is CONNECTING/DISCONNECTED
  - Add test for publish failure on CONNECTING state with queueMessages=false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed Behavior**
  * The queue_messages option now defaults to True, so messages are queued during connection transitions by default.
  * Publishing behavior around the INITIALIZED/connecting/disconnected states was tightened: messages are queued by default and may be rejected when queuing is explicitly disabled.

* **Tests**
  * Added tests verifying the default queue_messages value and that publishing fails in INITIALIZED when queue_messages is false.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->