### PR TITLE
fix: log connection state when unable to attach

### DIFF
--- a/ably/realtime/channel.py
+++ b/ably/realtime/channel.py
@@ -128,13 +128,14 @@ class RealtimeChannel(EventEmitter, Channel):
         self.__error_reason = None
 
         # RTL4b
-        if self.__realtime.connection.state not in [
+        connection_state = self.__realtime.connection.state
+        if connection_state not in [
             ConnectionState.CONNECTING,
             ConnectionState.CONNECTED,
             ConnectionState.DISCONNECTED
         ]:
             raise AblyException(
-                message=f"Unable to attach; channel state = {self.state}",
+                message=f"Unable to attach channel; connection state = {connection_state}",
                 code=90001,
                 status_code=400
             )


### PR DESCRIPTION
this log was unhelpfully printing the channel state when it's actually the connection state preventing the channel from attaching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when channel attachment fails; error messages now report connection state information more accurately to help diagnose connection-related issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->