### PR TITLE
ci: restore required permissions for the Features reusable workflow

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -11,7 +11,9 @@ permissions: {}
 jobs:
   build:
     permissions:
-      contents: read
+      contents: read       # checkout
+      deployments: write   # ably/sdk-upload-action
+      id-token: write      # aws-actions/configure-aws-credentials (OIDC)
     uses: ably/features/.github/workflows/sdk-features.yml@main
     with:
       repository-name: ably-python


### PR DESCRIPTION
## Context

PR #678 (GitHub Actions workflow security cleanup) added a top-level `permissions: {}` to `features.yml` and granted the `build` job only `contents: read`.

That `build` job calls the reusable workflow `ably/features/.github/workflows/sdk-features.yml@main`, whose job declares it needs:

```yaml
permissions:
  deployments: write
  id-token: write
```

For reusable workflows, **the caller's job permissions cap what the called workflow receives** — a called workflow cannot elevate beyond what the caller grants. With the caller capped at `contents: read`, the reusable workflow lost `id-token: write` (used by `aws-actions/configure-aws-credentials` for OIDC) and `deployments: write` (used by `ably/sdk-upload-action`), producing an invisible failure at workflow startup. The Features workflow is currently broken on `main`.

Flagged by @VeskeR on https://github.com/ably/ably-dotnet/pull/1328 and observed failing on [ably-python run 26639799574](https://github.com/ably/ably-python/actions/runs/26639799574), as well as ably-js and ably-dotnet.

## Change

Grant the two missing scopes on the calling job. Top-level `permissions: {}` is left intact.

```yaml
  build:
    permissions:
      contents: read       # checkout
      deployments: write   # ably/sdk-upload-action
      id-token: write      # aws-actions/configure-aws-credentials (OIDC)
    uses: ably/features/.github/workflows/sdk-features.yml@main
```

## Follow-up

The same one-line fix is needed in sibling SDK repos (ably-js, ably-dotnet, possibly others). Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
